### PR TITLE
Fix issue #21

### DIFF
--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -6,7 +6,7 @@
 #include "../debug.h"
 #include "timer.h"
 
-#define MAIN "main"
+#define MAIN "bench"
 #define MAX_PATH 100
 #define MAX_BYTE_CODE_SIZE 10000
 #define BENCHMARK_PATH "./tasks/"

--- a/benchmarks/tasks/catalan/wast/impl.c
+++ b/benchmarks/tasks/catalan/wast/impl.c
@@ -19,7 +19,7 @@ ull __attribute__((noinline)) catalan(int n) {
     return binomial(2 * n, n) / (1 + n);
 }
 
-int main() {
+int bench() {
     // printf("%lu!!",catalan(17) );
     int sum = 0;
 

--- a/benchmarks/tasks/fac/wast/impl.c
+++ b/benchmarks/tasks/fac/wast/impl.c
@@ -6,7 +6,7 @@ unsigned long __attribute__((noinline)) fac(int x) {
     }
 }
 
-int main() {
+int bench() {
     int sum = 0;
 #pragma nounroll
     for (int i = 0; i < 10000; i++) {

--- a/benchmarks/tasks/fib/wast/impl.c
+++ b/benchmarks/tasks/fib/wast/impl.c
@@ -12,7 +12,7 @@ long __attribute__((noinline)) fib(int n) {
     return next;
 }
 
-int main() {
+int bench() {
     int sum = 0;
 #pragma nounroll
     for (int i = 1000; i < 1050; i++) {

--- a/benchmarks/tasks/gcd/wast/impl.c
+++ b/benchmarks/tasks/gcd/wast/impl.c
@@ -2,7 +2,7 @@ int __attribute__((noinline)) gcd(int u, int v) {
     return (v != 0) ? gcd(v, u % v) : u;
 }
 
-int main() {
+int bench() {
     int sum = 0;
     for (int i = 40000; i < 50000; i++) {
         sum += gcd(i, 12345);

--- a/benchmarks/tasks/primes/wast/impl.c
+++ b/benchmarks/tasks/primes/wast/impl.c
@@ -31,7 +31,7 @@ int __attribute__((noinline)) is_prime(unsigned n) {
        i ← i + 6
     return true
  * */
-int main() {
+int bench() {
     unsigned sum = 0;
     int count = 0;
     for (unsigned i = 1; sum < 13374242; i++) {

--- a/benchmarks/tasks/tak-mem/wast/impl.c
+++ b/benchmarks/tasks/tak-mem/wast/impl.c
@@ -6,4 +6,4 @@ int tak(int x, int y, int z) {
     }
 }
 
-int main() { return tak(18, 12, 6); }
+int bench() { return tak(18, 12, 6); }

--- a/benchmarks/tasks/tak/wast/impl.c
+++ b/benchmarks/tasks/tak/wast/impl.c
@@ -6,4 +6,4 @@ int __attribute__((noinline)) tak(int x, int y, int z) {
     }
 }
 
-int main() { return tak(18, 12, 6); }
+int bench() { return tak(18, 12, 6); }

--- a/instructions.cpp
+++ b/instructions.cpp
@@ -44,8 +44,7 @@ Block *pop_block(Module *m) {
     // Restore stack pointer
     if (t->result_count == 1) {
         // Save top value as result
-        if (-2 < frame->sp &&
-            frame->sp < m->sp) {  // TODO frame->sp should never be < -1
+        if (frame->sp < m->sp) {
             m->stack[frame->sp + 1] = m->stack[m->sp];
             m->sp = frame->sp + 1;
         }


### PR DESCRIPTION
The buffer underflow caused by a `frame->sp` that is lower than -1 turned out to be a benchmark specific bug.

The `run_benchmarks` function in `benchmarks.cpp` uses the `invoke` function to call the main of each benchmark module.
Compiling the C programs with clang 13.0 results in a Wasm main function expecting three arguments as the main function in C expects an `int `and a `char**` parameter.
The `run_benchmarks` function did not account for this and did not push any parameters on the stack and called the function with 3 parameters anyway, naturally causing a buffer underflow.

**Implemented solution:** Rename the main function in the C implementations to "bench", so we can invoke a "bench" function that takes no parameters in `benchmarks.cpp` rather than a main that expects two parameters.