### PR TITLE
Add primitive type to struct when installing

### DIFF
--- a/src/Primitives/primitives.cpp
+++ b/src/Primitives/primitives.cpp
@@ -86,6 +86,7 @@ double sensor_emu = 0;
         if (prim_index < ALL_PRIMITIVES) {                                 \
             PrimitiveEntry *p = &primitives[prim_index++];                 \
             p->name = #prim_name;                                          \
+            p->t = prim_name##_type;                                       \
             p->f = &(prim_name);                                           \
         } else {                                                           \
             FATAL("pim_index out of bounds");                              \


### PR DESCRIPTION
The types of the primitives seem not to be stored by the install macro. This PR fixes that.