### PR TITLE
Fix breakpoint notification

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -89,6 +89,10 @@ bool Debugger::isBreakpoint(uint8_t *loc) {
     return this->breakpoints.find(loc) != this->breakpoints.end();
 }
 
+void Debugger::notifyBreakpoint(uint8_t *pc_ptr) {
+    dprintf(this->socket, "AT %p!\n", (void *)pc_ptr);
+}
+
 /**
  * Validate if there are interrupts and execute them
  *

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -88,4 +88,6 @@ class Debugger {
     void deleteBreakpoint(uint8_t *loc);
 
     bool isBreakpoint(uint8_t *loc);
+
+    void notifyBreakpoint(uint8_t *pc_ptr);
 };

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1493,7 +1493,7 @@ bool interpret(Module *m) {
         if (m->warduino->debugger->isBreakpoint(m->pc_ptr) &&
             m->warduino->debugger->skipBreakpoint != m->pc_ptr) {
             program_state = WARDUINOpause;
-            printf("AT %p!\n", (void *)m->pc_ptr);
+            m->warduino->debugger->notifyBreakpoint(m->pc_ptr);
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;


### PR DESCRIPTION
**Bug:** WARDuino reports a breakpoint was hit with the message: `"AT {program pointer}!"` However, this messages was still printed to `stdout` and not the debugger socket. Subsequently, breakpoints did not work in the plugin with the emulator.

**Fix:** Added a `Debugger::notifyBreakpoint` method.