### PR TITLE
Enhancement/126 Only virtual addresses

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -361,12 +361,6 @@ void Debugger::handleInterruptRUN(Module *m, RunningState *program_state) {
 void Debugger::handleInterruptBP(Module *m, uint8_t *interruptData) {
     uint8_t *bpData = interruptData + 1;
     uint32_t virtualAddress = read_B32(&bpData);
-    if (virtualAddress >= m->byte_count) {
-        // TODO handle incorrect data properly
-        FATAL("provided BP is out-of-scope: wasm size %" PRIu32
-              " BP is %" PRIu32,
-              m->byte_count, virtualAddress);
-    }
     uint8_t *bpt = toPhysicalAddress(virtualAddress, m);
     if (*interruptData == 0x06) {
         this->addBreakpoint(bpt);

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -131,8 +131,8 @@ bool Debugger::isBreakpoint(uint8_t *loc) {
     return this->breakpoints.find(loc) != this->breakpoints.end();
 }
 
-void Debugger::notifyBreakpoint(uint8_t *pc_ptr) const {
-    this->channel->write("AT %p!\n", (void *)pc_ptr);
+void Debugger::notifyBreakpoint(uint32_t bp) const {
+    this->channel->write("AT %" PRIu32 "!\n", bp);
 }
 
 /**

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -810,16 +810,18 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
     while (program_state < end_state) {
         switch (*program_state++) {
             case pcState: {  // PC
-                m->pc_ptr = (uint8_t *)readPointer(&program_state);
-                debug("receiving pc %p\n", static_cast<void *>(m->pc_ptr));
+                uint32_t pc = read_B32(&program_state);
+                m->pc_ptr = toPhysicalAddress(pc, m);
+                printf("Updated pc %" PRIu32 "\n", pc);
                 break;
             }
             case breakpointsState: {  // breakpoints
                 uint8_t quantity_bps = *program_state++;
                 debug("receiving breakpoints %" PRIu8 "\n", quantity_bps);
                 for (size_t i = 0; i < quantity_bps; i++) {
-                    auto bp = (uint8_t *)readPointer(&program_state);
-                    this->addBreakpoint(bp);
+                    auto virtualBP = read_B32(&program_state);
+                    this->addBreakpoint(toPhysicalAddress(virtualBP, m));
+                    printf("add breakpoint %" PRIu32 "\n", virtualBP);
                 }
                 break;
             }
@@ -835,7 +837,9 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                     Frame *f = m->callstack + m->csp;
                     f->sp = read_B32_signed(&program_state);
                     f->fp = read_B32_signed(&program_state);
-                    f->ra_ptr = (uint8_t *)readPointer(&program_state);
+                    auto virtualRA = read_B32(&program_state);
+                    printf("frame return address %" PRIu32 "\n", virtualRA);
+                    f->ra_ptr = toPhysicalAddress(virtualRA, m);
                     if (block_type == 0) {  // a function
                         debug("function block\n");
                         uint32_t fidx = read_B32(&program_state);
@@ -850,8 +854,9 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                         m->fp = f->sp + 1;
                     } else {
                         debug("non function block\n");
-                        auto *block_key =
-                            (uint8_t *)readPointer(&program_state);
+                        auto virtualBK = read_B32(&program_state);
+                        printf("frame block key %" PRIu32 "\n", virtualBK);
+                        auto *block_key = toPhysicalAddress(virtualBK, m);
                         /* debug("block_key=%p\n", static_cast<void
                          * *>(block_key)); */
                         f->block = m->block_lookup[block_key];

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -232,11 +232,6 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             free(interruptData);
             woodDump(m);
             break;
-        case interruptOffset:
-            free(interruptData);
-            printf("offset\n");
-            this->channel->write("{\"offset\":\"%p\"}\n", (void *)m->bytes);
-            break;
         case interruptRecvState:
             if (!this->receivingData) {
                 *program_state = WARDUINOpause;

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -98,7 +98,7 @@ class Debugger {
 
     void handleInterruptRUN(Module *m, RunningState *program_state);
 
-    void handleInterruptBP(const uint8_t *interruptData);
+    void handleInterruptBP(Module *m, uint8_t *interruptData);
 
     //// Information dumps
 

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -170,7 +170,7 @@ class Debugger {
 
     bool isBreakpoint(uint8_t *loc);
 
-    void notifyBreakpoint(uint8_t *pc_ptr) const;
+    void notifyBreakpoint(uint32_t bp) const;
 
     // Out-of-place debugging
 

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -48,7 +48,6 @@ enum InterruptTypes {
 
     // Pull Debugging
     interruptWOODDUMP = 0x60,
-    interruptOffset = 0x61,
     interruptRecvState = 0x62,
     interruptMonitorProxies = 0x63,
     interruptProxyCall = 0x64,

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1537,7 +1537,8 @@ bool interpret(Module *m) {
             m->warduino->debugger->skipBreakpoint != m->pc_ptr &&
             m->warduino->program_state != PROXYrun) {
             m->warduino->program_state = WARDUINOpause;
-            m->warduino->debugger->notifyBreakpoint(m->pc_ptr);
+            m->warduino->debugger->notifyBreakpoint(
+                toVirtualAddress(m->pc_ptr, m));
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;

--- a/src/WARDuino.h
+++ b/src/WARDuino.h
@@ -172,6 +172,9 @@ typedef struct Module {
     char *exception = nullptr;  // exception is set when the program fails
 } Module;
 
+uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m);
+uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m);
+
 typedef bool (*Primitive)(Module *);
 
 typedef struct PrimitiveEntry {

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -1024,3 +1024,17 @@ uint32_t WARDuino::get_main_fidx(Module *m) {
     if (fidx == UNDEF) fidx = this->get_export_fidx(m, "_Main");
     return fidx;
 }
+
+uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m) {
+    if (physicalAddr - m->bytes < 0) {
+        FATAL(
+            "INVALID Addresses: physicalAddr=%p WasmPhysicalAddr=%p "
+            "(Virtual address = %d)",
+            (void *)physicalAddr, (void *)m->bytes, physicalAddr - m->bytes);
+    }
+    return physicalAddr - m->bytes;
+}
+
+uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m) {
+    return m->bytes + virtualAddr;
+}

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -1036,5 +1036,10 @@ uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m) {
 }
 
 uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m) {
+    if (virtualAddr >= m->byte_count) {
+        FATAL("Provided virtualAddress is not within the Wasm. Given %" PRIu32
+              " Wasm size %" PRIu32 "\n",
+              virtualAddr, m->byte_count)
+    }
     return m->bytes + virtualAddr;
 }


### PR DESCRIPTION
For now onwards, adding a breakpoint or requesting a wood dump works on virtual addresses rendering thus the `start` value irrelevant. The virtual addresses were not implemented for all interrupts (e.g., `interruptDump`) and this is because most of those interrupts will be removed once [enhancement 127: fine-grained state request and update](https://github.com/TOPLLab/WARDuino/issues/127) is implemented.