### PR TITLE
Feat/virtual address (old)

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -133,8 +133,8 @@ bool Debugger::isBreakpoint(uint8_t *loc) {
     return this->breakpoints.find(loc) != this->breakpoints.end();
 }
 
-void Debugger::notifyBreakpoint(uint8_t *pc_ptr) const {
-    this->channel->write("AT %p!\n", (void *)pc_ptr);
+void Debugger::notifyBreakpoint(uint32_t bp) const {
+    this->channel->write("AT %" PRIu32 "!\n", bp);
 }
 
 /**

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -193,7 +193,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             break;
         case interruptBPAdd:  // Breakpoint
         case interruptBPRem:  // Breakpoint remove
-            this->handleInterruptBP(interruptData);
+            this->handleInterruptBP(m, interruptData);
             free(interruptData);
             break;
         case interruptDUMP:
@@ -390,22 +390,16 @@ void Debugger::handleInterruptRUN(Module *m, RunningState *program_state) {
     *program_state = WARDUINOrun;
 }
 
-void Debugger::handleInterruptBP(const uint8_t *interruptData) {
-    // TODO: segfault may happen here!
-    uint8_t len = interruptData[1];
-    uintptr_t bp = 0x0;
-    for (size_t i = 0; i < len; i++) {
-        bp <<= sizeof(uint8_t) * 8;
-        bp |= interruptData[i + 2];
-    }
-    auto *bpt = (uint8_t *)bp;
-    this->channel->write("BP %p!\n", static_cast<void *>(bpt));
-
+void Debugger::handleInterruptBP(Module *m, uint8_t *interruptData) {
+    uint8_t *bpData = interruptData + 1;
+    uint32_t virtualAddress = read_B32(&bpData);
+    uint8_t *bpt = toPhysicalAddress(virtualAddress, m);
     if (*interruptData == 0x06) {
         this->addBreakpoint(bpt);
     } else {
         this->deleteBreakpoint(bpt);
     }
+    this->channel->write("BP %" PRIu32 "!\n", virtualAddress);
 }
 
 void Debugger::dump(Module *m, bool full) const {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -242,11 +242,6 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             free(interruptData);
             woodDump(m);
             break;
-        case interruptOffset:
-            free(interruptData);
-            printf("offset\n");
-            this->channel->write("{\"offset\":\"%p\"}\n", (void *)m->bytes);
-            break;
         case interruptRecvState:
             if (!this->receivingData) {
                 *program_state = WARDUINOpause;

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -52,7 +52,6 @@ enum InterruptTypes {
 
     // Pull Debugging
     interruptWOODDUMP = 0x60,
-    interruptOffset = 0x61,
     interruptRecvState = 0x62,
     interruptMonitorProxies = 0x63,
     interruptProxyCall = 0x64,

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -184,7 +184,7 @@ class Debugger {
 
     bool isBreakpoint(uint8_t *loc);
 
-    void notifyBreakpoint(uint8_t *pc_ptr) const;
+    void notifyBreakpoint(uint32_t bp) const;
 
     // Out-of-place debugging
 

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -103,7 +103,7 @@ class Debugger {
 
     void handleInterruptRUN(Module *m, RunningState *program_state);
 
-    void handleInterruptBP(const uint8_t *interruptData);
+    void handleInterruptBP(Module *m, uint8_t *interruptData);
 
     //// Information dumps
 

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1545,7 +1545,8 @@ bool interpret(Module *m, bool waiting) {
             m->warduino->debugger->skipBreakpoint != m->pc_ptr &&
             m->warduino->program_state != PROXYrun) {
             m->warduino->program_state = WARDUINOpause;
-            m->warduino->debugger->notifyBreakpoint(m->pc_ptr);
+            m->warduino->debugger->notifyBreakpoint(
+                toVirtualAddress(m->pc_ptr, m));
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;

--- a/src/Utils/util.cpp
+++ b/src/Utils/util.cpp
@@ -281,3 +281,18 @@ unsigned short int sizeof_valuetype(uint32_t vt) {
             return sizeof(double);
     }
 }
+
+uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m) {
+    if (physicalAddr - m->bytes < 0) {
+        FATAL(
+            "INVALID address conversion: physicalAddr=%p WasmPhysicalAddr=%p "
+            "(Virtual address = %ld)",
+            (void *)physicalAddr, (void *)m->bytes,
+            (int)(physicalAddr - m->bytes));
+    }
+    return physicalAddr - m->bytes;
+}
+
+uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m) {
+    return m->bytes + virtualAddr;
+}

--- a/src/Utils/util.cpp
+++ b/src/Utils/util.cpp
@@ -286,7 +286,7 @@ uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m) {
     if (physicalAddr - m->bytes < 0) {
         FATAL(
             "INVALID address conversion: physicalAddr=%p WasmPhysicalAddr=%p "
-            "(Virtual address = %ld)",
+            "(Virtual address = %d)",
             (void *)physicalAddr, (void *)m->bytes,
             (int)(physicalAddr - m->bytes));
     }

--- a/src/Utils/util.cpp
+++ b/src/Utils/util.cpp
@@ -294,5 +294,12 @@ uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m) {
 }
 
 uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m) {
+    if (virtualAddr >= m->byte_count) {
+        FATAL(
+            "INVALID address conversion:"
+            "virtual address %" PRIu32 " is not within the Wasm size %" PRIu32
+            "\n",
+            virtualAddr, m->byte_count)
+    }
     return m->bytes + virtualAddr;
 }

--- a/src/Utils/util.h
+++ b/src/Utils/util.h
@@ -97,4 +97,22 @@ void chars_as_hexa(unsigned char *dest, unsigned char *source,
 
 unsigned short int sizeof_valuetype(uint32_t);
 
+/**
+ * Converts a physical address pointing to a Wasm instruction to a virtual
+ * address
+ *
+ * @param *physicalAddr pointer to Wasm
+ * @param *m pointer to module for which conversation needs to occur
+ * @return virtual address or FATAL
+ */
+uint32_t toVirtualAddress(uint8_t *physicalAddr, Module *m);
+
+/**
+ * The reverse process of toVirtualAddress
+ * @param virtualAddr the virtual address
+ * @param *m pointer to module for which conversation needs to occur
+ * @return physical address or FATAL
+ */
+uint8_t *toPhysicalAddress(uint32_t virtualAddr, Module *m);
+
 #endif


### PR DESCRIPTION
added the base functionality to start working with virtual addresses. However, currently when requesting state through interrupts as wooddump, dump, dumpfull, etc. The VM still prints physical addresses. And saving state via interruptRecvState also expects physical address via payload. 

Also  interruptOffset got removed which makes the interruptRecvState temporarily unusable. The reason is that we cannot push state to a VM without knowing the start address to calculate the physical address. Fixing this essentially corresponds with finishing the integration of issue https://github.com/TOPLLab/WARDuino/issues/127, which is best done in a separate PR to keep this PR relatively small.