### PR TITLE
Add update stackvalue message

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -237,6 +237,10 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             this->handleUpdateGlobalValue(m, interruptData + 1);
             free(interruptData);
             break;
+        case interruptUPDATEStackValue:
+            this->handleUpdateStackValue(m, interruptData + 1);
+            free(interruptData);
+            break;
         case interruptINVOKE:
             this->handleInvoke(m, interruptData + 1);
             free(interruptData);
@@ -1140,6 +1144,20 @@ bool Debugger::handleUpdateGlobalValue(Module *m, uint8_t *data) {
     bool decodeType = false;
     deserialiseStackValue(data, decodeType, v);
     this->channel->write("Global %u changed to %u\n", index, v->value.uint32);
+    return true;
+}
+
+bool Debugger::handleUpdateStackValue(Module *m, uint8_t *data) {
+    uint32_t idx = read_LEB_32(&data);
+    if (idx >= STACK_SIZE) {
+        return false;
+    }
+    StackValue *sv = &m->stack[idx];
+    bool decodeType = true;
+    if (!deserialiseStackValue(data, decodeType, sv)) {
+        return false;
+    }
+    this->channel->write("StackValue %" PRIu32 "changed\n", idx);
     return true;
 }
 

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1157,7 +1157,7 @@ bool Debugger::handleUpdateStackValue(Module *m, uint8_t *data) {
     if (!deserialiseStackValue(data, decodeType, sv)) {
         return false;
     }
-    this->channel->write("StackValue %" PRIu32 "changed\n", idx);
+    this->channel->write("StackValue %" PRIu32 " changed\n", idx);
     return true;
 }
 

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1137,20 +1137,8 @@ bool Debugger::handleUpdateGlobalValue(Module *m, uint8_t *data) {
 
     this->channel->write("Global %u being changed\n", index);
     StackValue *v = &m->globals[index];
-    switch (v->value_type) {
-        case I32:
-            v->value.uint32 = read_LEB_signed(&data, 32);
-            break;
-        case I64:
-            v->value.int64 = read_LEB_signed(&data, 64);
-            break;
-        case F32:
-            memcpy(&v->value.uint32, data, 4);
-            break;
-        case F64:
-            memcpy(&v->value.uint64, data, 8);
-            break;
-    }
+    bool decodeType = false;
+    deserialiseStackValue(data, decodeType, v);
     this->channel->write("Global %u changed to %u\n", index, v->value.uint32);
     return true;
 }

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1153,7 +1153,7 @@ bool Debugger::handleUpdateStackValue(Module *m, uint8_t *data) {
         return false;
     }
     StackValue *sv = &m->stack[idx];
-    bool decodeType = true;
+    bool decodeType = false;
     if (!deserialiseStackValue(data, decodeType, sv)) {
         return false;
     }

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -47,6 +47,7 @@ enum InterruptTypes {
     interruptUPDATELocal = 0x21,
     interruptUPDATEModule = 0x22,
     interruptUPDATEGlobal = 0x23,
+    interruptUPDATEStackValue = 0x24,
 
     // Remote REPL
     interruptINVOKE = 0x40,
@@ -133,6 +134,8 @@ class Debugger {
     bool handleUpdateModule(Module *m, uint8_t *data);
 
     bool handleUpdateGlobalValue(Module *m, uint8_t *data);
+
+    bool handleUpdateStackValue(Module *m, uint8_t *bytes);
 
     bool reset(Module *m);
 

--- a/src/Utils/util.cpp
+++ b/src/Utils/util.cpp
@@ -118,14 +118,30 @@ StackValue *readWasmArgs(Type function, uint8_t *data) {
     return args;
 }
 
-bool deserialiseStackValue(uint8_t *input, StackValue *value) {
-    uint8_t valtypes[] = {I32, I64, F32, F64};
-    uint8_t type_index = *input++;
-    if (type_index >= sizeof(valtypes)) return false;
-    value->value.uint64 = 0;  // init whole union to 0
-    size_t qb = type_index == 0 || type_index == 2 ? 4 : 8;
-    value->value_type = valtypes[type_index];
-    memcpy(&value->value, input, qb);
+bool deserialiseStackValue(uint8_t *input, bool decodeType, StackValue *value) {
+    if (decodeType) {
+        uint8_t valtypes[] = {I32, I64, F32, F64};
+        uint8_t type_index = *input++;
+        if (type_index >= sizeof(valtypes)) return false;
+        value->value.uint64 = 0;  // init whole union to 0
+        value->value_type = valtypes[type_index];
+    }
+    switch (value->value_type) {
+        case I32:
+            value->value.uint32 = read_LEB_signed(&input, 32);
+            break;
+        case I64:
+            value->value.int64 = read_LEB_signed(&input, 64);
+            break;
+        case F32:
+            memcpy(&value->value.uint32, input, 4);
+            break;
+        case F64:
+            memcpy(&value->value.uint64, input, 8);
+            break;
+        default:
+            return false;
+    }
     return true;
 }
 

--- a/src/Utils/util.h
+++ b/src/Utils/util.h
@@ -63,7 +63,7 @@ StackValue *readWasmArgs(Type function, uint8_t *data);
  * @param value
  * @return True if successful
  */
-bool deserialiseStackValue(uint8_t *input, StackValue *value);
+bool deserialiseStackValue(uint8_t *input, bool decodeType, StackValue *value);
 
 // Parse strings
 

--- a/tests/vm_unit_tests/serialisation_test.cpp
+++ b/tests/vm_unit_tests/serialisation_test.cpp
@@ -316,6 +316,23 @@ TEST_F(SerialisationFixture, DeserialiseNegativeF64StackValue) {
         << "Deserialisation value does not match expected value";
 }
 
+TEST_F(SerialisationFixture, DeserialiseInvalidType) {
+    const bool includeType = true;
+    uint8_t invalidType = 23;
+
+    double newValue{23};
+
+    StackValue* freshSV = this->newStackValue();
+    uint8_t* conversion = this->serialiseF64(newValue, includeType);
+
+    //change type
+    conversion[0] = invalidType;
+
+    bool successful = deserialiseStackValue(conversion, includeType, freshSV);
+    ASSERT_FALSE(successful) << "Deserialisation should fail for "
+                                "an invalid type";
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/tests/vm_unit_tests/serialisation_test.cpp
+++ b/tests/vm_unit_tests/serialisation_test.cpp
@@ -325,7 +325,7 @@ TEST_F(SerialisationFixture, DeserialiseInvalidType) {
     StackValue* freshSV = this->newStackValue();
     uint8_t* conversion = this->serialiseF64(newValue, includeType);
 
-    //change type
+    // change type
     conversion[0] = invalidType;
 
     bool successful = deserialiseStackValue(conversion, includeType, freshSV);

--- a/tests/vm_unit_tests/serialisation_test.cpp
+++ b/tests/vm_unit_tests/serialisation_test.cpp
@@ -1,0 +1,115 @@
+#include "../../src/Utils/util.h"
+#include "../../src/WARDuino.h"
+#include "gtest/gtest.h"
+
+class SerialisationFixture : public ::testing::Test {
+   protected:
+    StackValue i32sv{};
+    StackValue f32sv{};
+    StackValue i64sv{};
+    StackValue f64sv{};
+    std::map<uint8_t, uint8_t> typesMap{{I32, 0}, {I64, 1}, {F32, 2}, {F64, 3}};
+
+    std::vector<uint8_t*> conversionsToFree{};
+    std::vector<StackValue*> svToFree{};
+
+    ~SerialisationFixture() override {}
+
+    void SetUp() override {
+        // init whole values to 0
+        this->i32sv.value.uint64 = 0;
+        this->f32sv.value.uint64 = 0;
+        this->i64sv.value.uint64 = 0;
+        this->f64sv.value.uint64 = 0;
+
+        this->i32sv.value_type = I32;
+        this->f32sv.value_type = F32;
+        this->i64sv.value_type = I64;
+        this->f64sv.value_type = F64;
+    }
+
+    void TearDown() override {
+        for (int i = 0; i < this->conversionsToFree.size(); i++) {
+            delete this->conversionsToFree[i];
+        }
+        this->conversionsToFree.clear();
+        for (int i = 0; i < this->svToFree.size(); i++) {
+            delete this->svToFree[i];
+        }
+        this->svToFree.clear();
+    }
+
+    StackValue* newStackValue() {
+        auto sv = new StackValue{};
+        this->svToFree.push_back(sv);
+        return sv;
+    }
+
+    uint8_t* serialiseU32(uint32_t value, bool includeType) {
+        if (includeType) {
+            uint8_t typeIdx = this->typesMap[I32];
+            return this->integerToLEB128(value, &typeIdx);
+        } else {
+            return this->integerToLEB128(value);
+        }
+    }
+
+    uint8_t* integerToLEB128(int64_t value, uint8_t* putInFront = nullptr) {
+        std::vector<uint8_t> buffer;
+        bool more = true;
+        while (more) {
+            uint8_t byte = value & 0x7F;
+            value >>= 7;
+            if ((value == 0 && (byte & 0x40) == 0) ||
+                (value == -1 && (byte & 0x40) != 0)) {
+                more = false;
+            } else {
+                byte |= 0x80;
+            }
+            buffer.push_back(byte);
+        }
+        if (putInFront != nullptr) {
+            buffer.insert(buffer.begin(), *putInFront);
+        }
+        uint8_t* result = new uint8_t[buffer.size()];
+        for (size_t i = 0; i < buffer.size(); ++i) {
+            result[i] = buffer[i];
+        }
+        this->conversionsToFree.push_back(result);
+        return result;
+    }
+};
+
+TEST_F(SerialisationFixture, DeserialisePositiveU32StackValueAndIgnoreType) {
+    const bool includeType = false;
+    int64_t newValue = 127;
+    uint8_t* conversion = this->serialiseU32(newValue, includeType);
+
+    bool successful =
+        deserialiseStackValue(conversion, includeType, &this->i32sv);
+    ASSERT_TRUE(successful) << "Deserialisation should be successful";
+    EXPECT_EQ(this->i32sv.value_type, I32)
+        << "Deserialisation should preserve type. ";
+    EXPECT_EQ(this->i32sv.value.uint32, newValue)
+        << "Deserialisation value does not match expected value";
+}
+
+TEST_F(SerialisationFixture, DeserialisePositiveU32StackValue) {
+    const bool includeType = true;
+    int64_t newValue = 127;
+    uint8_t* conversion = this->serialiseU32(newValue, includeType);
+    StackValue* freshSV = this->newStackValue();
+
+    bool successful = deserialiseStackValue(conversion, includeType, freshSV);
+
+    ASSERT_TRUE(successful) << "Deserialisation should be successful";
+    EXPECT_EQ(freshSV->value_type, I32)
+        << "Deserialisation should deserialise value type. ";
+    EXPECT_EQ(freshSV->value.uint32, newValue)
+        << "Deserialisation value does not match expected value";
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR adds to WARDuino the ability to update stack values. Concretely what the PR does:
- refactored the interruptUPDATEGlobal to use deserialiseStackValue
- add unit tests for the deserialiseStackValue
- add interrupt to update StackValue