### PR TITLE
Step over

### DIFF
--- a/platforms/CLI-Emulator/main.cpp
+++ b/platforms/CLI-Emulator/main.cpp
@@ -340,7 +340,7 @@ int main(int argc, const char *argv[]) {
     m->warduino = wac;
 
     if (initiallyPaused) {
-        wac->program_state = WARDUINOpause;
+        wac->debugger->pauseRuntime(m);
     }
 
     if (m) {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -184,7 +184,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             free(interruptData);
             exit(0);
         case interruptPAUSE:
-            *program_state = WARDUINOpause;
+            this->pauseRuntime(m);
             this->channel->write("PAUSE!\n");
             free(interruptData);
             break;
@@ -202,18 +202,18 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             free(interruptData);
             break;
         case interruptDUMP:
-            *program_state = WARDUINOpause;
+            this->pauseRuntime(m);
             this->dump(m);
             free(interruptData);
             break;
         case interruptDUMPLocals:
-            *program_state = WARDUINOpause;
+            this->pauseRuntime(m);
             this->dumpLocals(m);
             this->channel->write("\n");
             free(interruptData);
             break;
         case interruptDUMPFull:
-            *program_state = WARDUINOpause;
+            this->pauseRuntime(m);
             this->dump(m, true);
             free(interruptData);
             break;
@@ -251,7 +251,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             free(interruptData);
             break;
         case interruptSnapshot:
-            *program_state = WARDUINOpause;
+            this->pauseRuntime(m);
             free(interruptData);
             snapshot(m);
             break;
@@ -265,7 +265,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
         }
         case interruptLoadSnapshot:
             if (!this->receivingData) {
-                *program_state = WARDUINOpause;
+                this->pauseRuntime(m);
                 debug("paused program execution\n");
                 CallbackHandler::manual_event_resolution = true;
                 dbg_info("Manual event resolution is on.");
@@ -1265,6 +1265,12 @@ void Debugger::stop() {
         this->channel->close();
         this->channel = nullptr;
     }
+}
+
+//
+void Debugger::pauseRuntime(Module *m) {
+    m->warduino->program_state = WARDUINOpause;
+    this->mark = nullptr;
 }
 
 bool Debugger::handleUpdateModule(Module *m, uint8_t *data) {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -412,17 +412,15 @@ void Debugger::handleSTEP(Module *m, RunningState *program_state) {
     this->skipBreakpoint = m->pc_ptr;
 }
 
-bool atCall(Module *m) {
-    uint8_t const opcode = *m->pc_ptr;
-    return opcode == 0x10 || opcode == 0x11;
-}
-
 void Debugger::handleSTEPOver(Module *m, RunningState *program_state) {
-    if (atCall(m)) {
-        // step over call
+    uint8_t const opcode = *m->pc_ptr;
+    if (opcode == 0x10) {  // step over direct call
         this->mark = m->pc_ptr + 2;
         *program_state = WARDUINOrun;
         // warning: ack will be BP hit
+    } else if (opcode == 0x11) {  // step over indirect call
+        this->mark = m->pc_ptr + 3;
+        *program_state = WARDUINOrun;
     } else {
         // normal step
         this->handleSTEP(m, program_state);

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -50,6 +50,7 @@ enum InterruptTypes {
     interruptHALT = 0x02,
     interruptPAUSE = 0x03,
     interruptSTEP = 0x04,
+    interruptSTEPOver = 0x05,
     interruptBPAdd = 0x06,
     interruptBPRem = 0x07,
     interruptInspect = 0x09,
@@ -118,6 +119,10 @@ class Debugger {
 
     void handleInterruptRUN(Module *m, RunningState *program_state);
 
+    void handleSTEP(Module *m, RunningState *program_state);
+
+    void handleSTEPOver(Module *m, RunningState *program_state);
+
     void handleInterruptBP(Module *m, uint8_t *interruptData);
 
     //// Information dumps
@@ -175,6 +180,8 @@ class Debugger {
     ProxySupervisor *supervisor = nullptr;
 
     std::set<uint8_t *> breakpoints = {};  // Vector, we expect few breakpoints
+    uint8_t *mark = 0;  // a unique temporary breakpoint that gets removed
+                        // whenever a breakpoint is hit
     uint8_t *skipBreakpoint =
         nullptr;  // Breakpoint to skip in the next interpretation step
 
@@ -205,7 +212,7 @@ class Debugger {
 
     bool isBreakpoint(uint8_t *loc);
 
-    void notifyBreakpoint(Module *m, uint8_t *pc_ptr) const;
+    void notifyBreakpoint(Module *m, uint8_t *pc_ptr);
 
     // Out-of-place debugging: EDWARD
 

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -196,6 +196,8 @@ class Debugger {
 
     void stop();
 
+    void pauseRuntime(Module *m);  // pause runtime for given module
+
     // Interrupts
 
     void addDebugMessage(size_t len, const uint8_t *buff);

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1517,7 +1517,7 @@ bool interpret(Module *m, bool waiting) {
 
     while ((!program_done && success) || waiting) {
         if (m->warduino->program_state == WARDUINOstep) {
-            m->warduino->program_state = WARDUINOpause;
+            m->warduino->debugger->pauseRuntime(m);
         }
 
         while (m->warduino->program_state != WARDUINOinit &&
@@ -1550,7 +1550,7 @@ bool interpret(Module *m, bool waiting) {
         if (m->warduino->debugger->isBreakpoint(m->pc_ptr) &&
             m->warduino->debugger->skipBreakpoint != m->pc_ptr &&
             m->warduino->program_state != PROXYrun) {
-            m->warduino->program_state = WARDUINOpause;
+            m->warduino->debugger->pauseRuntime(m);
             m->warduino->debugger->notifyBreakpoint(m, m->pc_ptr);
             continue;
         }

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -930,7 +930,7 @@ int WARDuino::run_module(Module *m) {
     }
 
     // wait
-    m->warduino->program_state = WARDUINOpause;
+    m->warduino->debugger->pauseRuntime(m);
     return interpret(m, true);
 }
 
@@ -1044,7 +1044,7 @@ void WARDuino::update_module(Module *m, uint8_t *wasm, uint32_t wasm_len) {
     }
 
     // wait
-    m->warduino->program_state = WARDUINOpause;
+    m->warduino->debugger->pauseRuntime(m);
 }
 
 uint32_t WARDuino::get_main_fidx(Module *m) {

--- a/tests/latch/examples/call.wast
+++ b/tests/latch/examples/call.wast
@@ -1,0 +1,33 @@
+(module
+  ;; Type declarations
+  (type $int32->int32->void (func (param i32 i32)))
+  (type $int32->void (func (param i32)))
+  (type $void->void (func))
+
+  ;; Imports from the WARDuino VM
+  (import "env" "chip_pin_mode" (func $env.chip_pin_mode (type $int32->int32->void)))
+  (import "env" "print_int" (func $env.print_int (type $int32->void)))
+
+  ;; Non-mutable globals
+  (global $led i32 (i32.const 26))
+
+  (func $init (type $void->void)  ;; Set pin mode function (private)
+    global.get $led
+    i32.const 2
+    call $env.chip_pin_mode)
+
+  (func $on (type $void->void)
+    i32.const 42
+    call $env.print_int)  ;; print 42
+
+
+  (func $blink (type $void->void)  ;; Blink function (public)
+    call $init  ;; initialise
+    (i32.const 4)
+    call_indirect (type $void->void) )
+
+  (table 5 5 funcref)
+  (elem (i32.const 4) func $on)
+
+  ;; Export blink as function
+  (export "main" (func $blink)))

--- a/tests/latch/src/util/warduino.bridge.ts
+++ b/tests/latch/src/util/warduino.bridge.ts
@@ -28,7 +28,7 @@ export function isReadable(x: Readable | null): x is Readable {
 }
 
 export function startWARDuino(interpreter: string, program: string, port: number, args: string[] = []): ChildProcess {
-    const _args: string[] = [program, '--socket', (port).toString()].concat(args);
+    const _args: string[] = [program, '--socket', (port).toString(), '--paused'].concat(args);
     return spawn(interpreter, _args);
 }
 


### PR DESCRIPTION
Add a `STEPOver` debug message to step over function calls (both direct and indirect).

Implementation works with a unique mark, a breakpoint that gets removed whenever the virtual machine gets paused.
The step over runs the code until the mark, or an earlier breakpoint.