### PR TITLE
Fix step over not stepping if at a breakpoint placed on a call instruction

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -413,6 +413,7 @@ void Debugger::handleSTEP(Module *m, RunningState *program_state) {
 }
 
 void Debugger::handleSTEPOver(Module *m, RunningState *program_state) {
+    this->skipBreakpoint = m->pc_ptr;
     uint8_t const opcode = *m->pc_ptr;
     if (opcode == 0x10) {  // step over direct call
         this->mark = m->pc_ptr + 2;


### PR DESCRIPTION
Step over does not work if the current opcode is a call instruction and there is a breakpoint on it. The `handleSTEP` function skips breakpoints but if the current opcode is a call or indirect call instruction we just set a mark and put the vm in running state. If the current pc is a breakpoint the vm never goes any further because it instantly hits the breakpoint.