### PR TITLE
🐛 Fix emu to emu connection in out-of-place debugging

### DIFF
--- a/platforms/CLI-Emulator/main.cpp
+++ b/platforms/CLI-Emulator/main.cpp
@@ -351,7 +351,7 @@ int main(int argc, const char *argv[]) {
             Channel *connection = nullptr;
             try {
                 int port = std::stoi(proxy);
-                connection = new WebSocket(port);
+                connection = new ClientSocket(port);
             } catch (std::invalid_argument const &ex) {
                 // argument is not a port
                 // treat as filename

--- a/src/Utils/sockets.cpp
+++ b/src/Utils/sockets.cpp
@@ -116,6 +116,8 @@ WebSocket::WebSocket(int port) {
     this->socket = -1;
 }
 
+ClientSocket::ClientSocket(int server) : WebSocket(server) {}
+
 void WebSocket::open() {
     // bind socket to address
     this->fileDescriptor = createSocketFileDescriptor();
@@ -127,6 +129,18 @@ void WebSocket::open() {
 
     // block until a connection is established
     this->socket = listenForIncomingConnection(this->fileDescriptor, address);
+}
+
+void ClientSocket::open() {
+    // bind socket to address
+    this->fileDescriptor = createSocketFileDescriptor();
+    struct sockaddr_in address = createAddress(this->port);  // server port
+    int const result =
+        connect(this->socket, (struct sockaddr *)&address, sizeof(address));
+
+    if (result == 0) {
+        this->socket = this->fileDescriptor;
+    }
 }
 
 int WebSocket::write(const char *fmt, ...) const {

--- a/src/Utils/sockets.h
+++ b/src/Utils/sockets.h
@@ -56,7 +56,7 @@ class FileDescriptorChannel : public Channel {
 };
 
 class WebSocket : public Channel {
-   private:
+   protected:
     int port;
     int fileDescriptor;
     int socket;
@@ -68,4 +68,10 @@ class WebSocket : public Channel {
     int write(char const *fmt, ...) const override;
     ssize_t read(void *out, size_t size) override;
     void close() override;
+};
+
+class ClientSocket : public WebSocket {
+   public:
+    explicit ClientSocket(int server);
+    void open() override;
 };


### PR DESCRIPTION
**Adds a `ClientSocket : public WebSocket` class to correctly connect to proxy web socket.**

Fixes an issue when connecting two emulator instances in out-of-place debugging, where the following error was thrown:

```error
Binding socket to address failed: Address already in use
```

