### PR TITLE
Add async snapshot interrupt

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -848,7 +848,6 @@ void Debugger::inspect(Module *m, uint16_t sizeStateArray, uint8_t *state) {
                 break;
             }
         }
-        fflush(stdout);
     }
     this->channel->write("}\n");
 }

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -20,6 +20,7 @@ Debugger::Debugger(Channel *duplex) {
     this->channel = duplex;
     this->supervisor_mutex = new std::mutex();
     this->supervisor_mutex->lock();
+    this->asyncSnapshots = false;
 }
 
 // Public methods
@@ -255,6 +256,10 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             this->pauseRuntime(m);
             free(interruptData);
             snapshot(m);
+            break;
+        case interruptEnableSnapshots:
+            enableSnapshots(interruptData + 1);
+            free(interruptData);
             break;
         case interruptInspect: {
             uint8_t *data = interruptData + 1;
@@ -723,7 +728,6 @@ void Debugger::inspect(Module *m, uint16_t sizeStateArray, uint8_t *state) {
     auto toVA = [m](uint8_t *addr) { return toVirtualAddress(addr, m); };
     bool addComma = false;
 
-    this->channel->write("DUMP!\n");
     this->channel->write("{");
 
     while (idx < sizeStateArray) {
@@ -844,8 +848,20 @@ void Debugger::inspect(Module *m, uint16_t sizeStateArray, uint8_t *state) {
                 break;
             }
         }
+        fflush(stdout);
     }
     this->channel->write("}\n");
+}
+
+void Debugger::enableSnapshots(uint8_t *interruptData) {
+    asyncSnapshots = *interruptData;
+}
+
+void Debugger::sendAsyncSnapshots(Module *m) {
+    if (asyncSnapshots) {
+        this->channel->write("SNAPSHOT ");
+        snapshot(m);
+    }
 }
 
 void Debugger::freeState(Module *m, uint8_t *interruptData) {

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -112,7 +112,7 @@ class Debugger {
 
     bool connected_to_proxy = false;
     std::mutex *supervisor_mutex;
-    
+
     bool asyncSnapshots;
 
     // Private methods
@@ -234,9 +234,9 @@ class Debugger {
     // Out-of-place debugging: EDWARD
 
     void snapshot(Module *m);
-    
+
     void enableSnapshots(uint8_t *interruptData);
-    
+
     void sendAsyncSnapshots(Module *m);
 
     void proxify();

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -74,6 +74,7 @@ enum InterruptTypes {
 
     // Pull Debugging
     interruptSnapshot = 0x60,
+    interruptEnableSnapshots = 0x61,
     interruptLoadSnapshot = 0x62,
     interruptMonitorProxies = 0x63,
     interruptProxyCall = 0x64,
@@ -111,6 +112,8 @@ class Debugger {
 
     bool connected_to_proxy = false;
     std::mutex *supervisor_mutex;
+    
+    bool asyncSnapshots;
 
     // Private methods
 
@@ -231,6 +234,10 @@ class Debugger {
     // Out-of-place debugging: EDWARD
 
     void snapshot(Module *m);
+    
+    void enableSnapshots(uint8_t *interruptData);
+    
+    void sendAsyncSnapshots(Module *m);
 
     void proxify();
 

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1316,7 +1316,7 @@ bool interpret(Module *m, bool waiting) {
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;
-        
+
         // Take snapshot before executing an instruction
         m->warduino->debugger->sendAsyncSnapshots(m);
 

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -1316,6 +1316,9 @@ bool interpret(Module *m, bool waiting) {
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;
+        
+        // Take snapshot before executing an instruction
+        m->warduino->debugger->sendAsyncSnapshots(m);
 
         opcode = *m->pc_ptr;
         block_ptr = m->pc_ptr;

--- a/src/Interpreter/interpreter.cpp
+++ b/src/Interpreter/interpreter.cpp
@@ -238,6 +238,9 @@ bool Interpreter::interpret(Module *m, bool waiting) {
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;
+        
+        // Take snapshot before executing an instruction
+        m->warduino->debugger->sendAsyncSnapshots(m);
 
         opcode = *m->pc_ptr;
         block_ptr = m->pc_ptr;

--- a/src/Interpreter/interpreter.cpp
+++ b/src/Interpreter/interpreter.cpp
@@ -238,7 +238,7 @@ bool Interpreter::interpret(Module *m, bool waiting) {
             continue;
         }
         m->warduino->debugger->skipBreakpoint = nullptr;
-        
+
         // Take snapshot before executing an instruction
         m->warduino->debugger->sendAsyncSnapshots(m);
 


### PR DESCRIPTION
This PR adds a debugger interrupt that allows the VM to send a snapshot before every instruction it executes. This is useful for time travelling debuggers because it allows taking snapshots without pausing the VM.

The interrupt currently has number 61 associated with it (can be changed of course), I just noticed there was an empty spot right after snapshot. With `6101` you can enable tracing mode basically and with `6100` you can disable it again.

The `DUMP!` message printed before every snapshot is also removed, I did this to make it easier to add snapshot data to an existing line for example `SNAPSHOT {"pc": ...` which is the format used for this new interrupt. This format makes it easy to identify async snapshots. I just hope that `DUMP!` is not used by the plugin. The `DUMP!` message is also not mentioned in the documentation, it only mentions the json data which is unchanged so I assume that this will be fine.

One thing I noticed while preparing this PR, it appears we have 2 `interpret` functions now? The one in `instructions.cpp` can probably be removed?