### PR TITLE
Fix build by adding missing cstdint include

### DIFF
--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <queue>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
Tested with gcc (GCC) 13.2.1 20230801.

Fixed error was:
error: ‘uint32_t’ does not name a type

note: ‘uint32_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?