### PR TITLE
🚑 Migrate to Arduino esp32 v3

### DIFF
--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -591,22 +591,12 @@ def_prim(chip_ledc_set_duty, threeToNoneU32) {
     return true;
 }
 
-def_prim(chip_ledc_setup, threeToNoneU32) {
+def_prim(chip_ledc_attach, threeToNoneU32) {
     uint32_t channel = arg2.uint32;
     uint32_t freq = arg1.uint32;
-    uint32_t ledc_timer = arg0.uint32;
-    // printf("chip_ledc_setup(%u, %u, %u)\n", channel, freq, ledc_timer);
-    ledcSetup(channel, freq, ledc_timer);
+    uint32_t resolution = arg0.uint32;
+    ledcAttach(channel, freq, resolution);
     pop_args(3);
-    return true;
-}
-
-def_prim(chip_ledc_attach_pin, twoToNoneU32) {
-    uint32_t pin = arg1.uint32;
-    uint32_t channel = arg0.uint32;
-    // printf("chip_ledc_attach_pin(%u,%u)\n", pin, channel);
-    ledcAttachPin(pin, channel);
-    pop_args(2);
     return true;
 }
 
@@ -992,8 +982,7 @@ void install_primitives() {
 
     // temporary primitives needed for analogWrite in ESP32
     install_primitive(chip_analog_write);
-    install_primitive(chip_ledc_setup);
-    install_primitive(chip_ledc_attach_pin);
+    install_primitive(chip_ledc_attach);
     install_primitive(chip_ledc_set_duty);
 
     dbg_info("INSTALLING ISRs\n");


### PR DESCRIPTION
**💥 Breaking Changes to Arduino primitives interface**

Removes the following primitives:

- `chip_ledc_setup`
- `chip_ledc_attach_pin`

Adds the following primitives:

- `chip_ledc_attach`

supported version: `arduino-cli v0.35.3`