### PR TITLE
✨ Primitive mocking

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1,6 +1,7 @@
 #include "debugger.h"
 
 #include <algorithm>
+#include <optional>
 #include <cinttypes>
 #include <cstring>
 #ifndef ARDUINO
@@ -330,6 +331,14 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             break;
         case interruptDUMPCallbackmapping:
             this->dumpCallbackmapping();
+            free(interruptData);
+            break;
+        case interruptSetOverridePinValue:
+            this->addOverride(m, interruptData + 1);
+            free(interruptData);
+            break;
+        case interruptUnsetOverridePinValue:
+            this->removeOverride(m, interruptData + 1);
             free(interruptData);
             break;
         default:
@@ -1409,6 +1418,59 @@ bool Debugger::reset(Module *m) const {
     m->warduino->update_module(m, wasm, m->byte_count);
     this->channel->write("Reset WARDuino.\n");
     return true;
+}
+
+std::optional<uint32_t> resolve_imported_function(Module *m, std::string function_name) {
+    for (uint32_t fidx = 0; fidx < m->import_count; fidx++) {
+        if (!strcmp(m->functions[fidx].import_field, function_name.c_str())) {
+            return fidx;
+        }
+    }
+    return {};
+}
+
+std::string read_string(uint8_t **pos) {
+    std::string str = "";
+    char c = *(*pos)++;
+    while (c != '\0') {
+        str += c;
+        c = *(*pos)++;
+    }
+    return str;
+}
+
+void Debugger::addOverride(Module *m, uint8_t *interruptData) {
+    std::string primitive_name = read_string(&interruptData);
+    uint32_t arg = read_B32(&interruptData);
+    uint32_t result = read_B32(&interruptData);
+
+    std::optional<uint32_t> fidx = resolve_imported_function(m, primitive_name);
+    if (!fidx) {
+        channel->write("Cannot override the result for unknown function \"%s\".\n", primitive_name.c_str());
+        return;
+    }
+
+    channel->write("Override %s(%d) = %d.\n", primitive_name.c_str(), arg, result);
+    overrides[fidx.value()][arg] = result;
+}
+
+void Debugger::removeOverride(Module *m, uint8_t *interruptData) {
+    std::string primitive_name = read_string(&interruptData);
+    uint32_t arg = read_B32(&interruptData);
+
+    std::optional<uint32_t> fidx = resolve_imported_function(m, primitive_name);
+    if (!fidx) {
+        channel->write("Cannot remove override for unknown function \"%s\".\n", primitive_name.c_str());
+        return;
+    }
+
+    if (overrides[fidx.value()].count(arg) == 0) {
+        channel->write("Override for %s(%d) not found.\n", primitive_name.c_str(), arg);
+        return;
+    }
+
+    channel->write("Removing override %s(%d) = %d.\n", primitive_name.c_str(), arg, overrides[fidx.value()][arg]);
+    overrides[fidx.value()].erase(arg);
 }
 
 Debugger::~Debugger() {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1,9 +1,9 @@
 #include "debugger.h"
 
 #include <algorithm>
-#include <optional>
 #include <cinttypes>
 #include <cstring>
+#include <optional>
 #ifndef ARDUINO
 #include <nlohmann/json.hpp>
 #else
@@ -735,10 +735,18 @@ bool Debugger::handlePushedEvent(char *bytes) const {
 
 void Debugger::snapshot(Module *m) const {
     uint16_t numberBytes = 12;
-    uint8_t state[] = {
-        pcState,        breakpointsState, callstackState,      globalsState,
-        tableState,     memoryState,      branchingTableState, stackState,
-        callbacksState, eventsState,     ioState, overridesState};
+    uint8_t state[] = {pcState,
+                       breakpointsState,
+                       callstackState,
+                       globalsState,
+                       tableState,
+                       memoryState,
+                       branchingTableState,
+                       stackState,
+                       callbacksState,
+                       eventsState,
+                       ioState,
+                       overridesState};
     inspect(m, numberBytes, state);
 }
 
@@ -893,7 +901,7 @@ void Debugger::inspect(Module *m, const uint16_t sizeStateArray,
                 bool comma = false;
                 for (auto key : overrides) {
                     for (auto argResult : key.second) {
-                        this->channel->write("%s", comma ? ", ": "");
+                        this->channel->write("%s", comma ? ", " : "");
                         this->channel->write(
                             R"({"fidx": %d, "arg": %d, "return_value": %d})",
                             key.first, argResult.first, argResult.second);
@@ -1443,7 +1451,8 @@ bool Debugger::reset(Module *m) const {
     return true;
 }
 
-std::optional<uint32_t> resolve_imported_function(Module *m, std::string function_name) {
+std::optional<uint32_t> resolve_imported_function(Module *m,
+                                                  std::string function_name) {
     for (uint32_t fidx = 0; fidx < m->import_count; fidx++) {
         if (!strcmp(m->functions[fidx].import_field, function_name.c_str())) {
             return fidx;
@@ -1469,11 +1478,14 @@ void Debugger::addOverride(Module *m, uint8_t *interruptData) {
 
     std::optional<uint32_t> fidx = resolve_imported_function(m, primitive_name);
     if (!fidx) {
-        channel->write("Cannot override the result for unknown function \"%s\".\n", primitive_name.c_str());
+        channel->write(
+            "Cannot override the result for unknown function \"%s\".\n",
+            primitive_name.c_str());
         return;
     }
 
-    channel->write("Override %s(%d) = %d.\n", primitive_name.c_str(), arg, result);
+    channel->write("Override %s(%d) = %d.\n", primitive_name.c_str(), arg,
+                   result);
     overrides[fidx.value()][arg] = result;
 }
 
@@ -1483,16 +1495,19 @@ void Debugger::removeOverride(Module *m, uint8_t *interruptData) {
 
     std::optional<uint32_t> fidx = resolve_imported_function(m, primitive_name);
     if (!fidx) {
-        channel->write("Cannot remove override for unknown function \"%s\".\n", primitive_name.c_str());
+        channel->write("Cannot remove override for unknown function \"%s\".\n",
+                       primitive_name.c_str());
         return;
     }
 
     if (overrides[fidx.value()].count(arg) == 0) {
-        channel->write("Override for %s(%d) not found.\n", primitive_name.c_str(), arg);
+        channel->write("Override for %s(%d) not found.\n",
+                       primitive_name.c_str(), arg);
         return;
     }
 
-    channel->write("Removing override %s(%d) = %d.\n", primitive_name.c_str(), arg, overrides[fidx.value()][arg]);
+    channel->write("Removing override %s(%d) = %d.\n", primitive_name.c_str(),
+                   arg, overrides[fidx.value()][arg]);
     overrides[fidx.value()].erase(arg);
 }
 

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -734,18 +734,11 @@ bool Debugger::handlePushedEvent(char *bytes) const {
 }
 
 void Debugger::snapshot(Module *m) const {
-    uint16_t numberBytes = 11;
-    uint8_t state[] = {pcState,
-                       breakpointsState,
-                       callstackState,
-                       globalsState,
-                       tableState,
-                       memoryState,
-                       branchingTableState,
-                       stackState,
-                       callbacksState,
-                       eventsState,
-                       ioState};
+    uint16_t numberBytes = 12;
+    uint8_t state[] = {
+        pcState,        breakpointsState, callstackState,      globalsState,
+        tableState,     memoryState,      branchingTableState, stackState,
+        callbacksState, eventsState,     ioState, overridesState};
     inspect(m, numberBytes, state);
 }
 
@@ -889,6 +882,23 @@ void Debugger::inspect(Module *m, const uint16_t sizeStateArray,
                     this->channel->write("}");
                     comma = true;
                     delete state_elem;
+                }
+                this->channel->write("]");
+                addComma = true;
+                break;
+            }
+            case overridesState: {
+                this->channel->write("%s", addComma ? "," : "");
+                this->channel->write(R"("overrides": [)");
+                bool comma = false;
+                for (auto key : overrides) {
+                    for (auto argResult : key.second) {
+                        this->channel->write("%s", comma ? ", ": "");
+                        this->channel->write(
+                            R"({"fidx": %d, "arg": %d, "return_value": %d})",
+                            key.first, argResult.first, argResult.second);
+                        comma = true;
+                    }
                 }
                 this->channel->write("]");
                 addComma = true;
@@ -1247,6 +1257,19 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                           state_elem.value);
                 }
                 restore_external_state(m, external_state);
+                break;
+            }
+            case overridesState: {
+                debug("receiving overridesState\n");
+                overrides.clear();
+                uint8_t overrides_count = *program_state++;
+                for (uint32_t i = 0; i < overrides_count; i++) {
+                    uint32_t fidx = read_B32(&program_state);
+                    uint32_t arg = read_B32(&program_state);
+                    uint32_t return_value = read_B32(&program_state);
+                    overrides[fidx][arg] = return_value;
+                    debug("Override %d %d %d\n", fidx, arg, return_value);
+                }
                 break;
             }
             default: {

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -49,6 +49,7 @@ enum ExecutionState {
     callbacksState = 0x09,
     eventsState = 0x0A,
     ioState = 0x0B,
+    overridesState = 0x0C,
 };
 
 enum InterruptTypes {

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -90,10 +90,13 @@ enum InterruptTypes {
     interruptDUMPCallbackmapping = 0x74,
     interruptRecvCallbackmapping = 0x75,
 
+    // Primitive overrides
+    interruptSetOverridePinValue = 0x80,
+    interruptUnsetOverridePinValue = 0x81,
+
     // Operations
     interruptStore = 0xa0,
     interruptStored = 0xa1,
-
 };
 
 class Debugger {
@@ -116,6 +119,8 @@ class Debugger {
     warduino::mutex *supervisor_mutex;
 
     bool asyncSnapshots;
+
+    std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint32_t>> overrides;
 
     // Private methods
 
@@ -270,4 +275,11 @@ class Debugger {
     void notifyPushedEvent() const;
 
     bool handlePushedEvent(char *bytes) const;
+
+    // Concolic Multiverse Debugging
+    inline bool isMocked(uint32_t fidx, uint32_t argument) { return overrides.count(fidx) > 0 && overrides[fidx].count(argument) > 0; }
+    inline uint32_t getMockedValue(uint32_t fidx, uint32_t argument) { return overrides[fidx][argument]; }
+
+    void addOverride(Module *m, uint8_t *interruptData);
+    void removeOverride(Module *m, uint8_t *interruptData);
 };

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -121,7 +121,8 @@ class Debugger {
 
     bool asyncSnapshots;
 
-    std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint32_t>> overrides;
+    std::unordered_map<uint32_t, std::unordered_map<uint32_t, uint32_t>>
+        overrides;
 
     // Private methods
 
@@ -278,8 +279,12 @@ class Debugger {
     bool handlePushedEvent(char *bytes) const;
 
     // Concolic Multiverse Debugging
-    inline bool isMocked(uint32_t fidx, uint32_t argument) { return overrides.count(fidx) > 0 && overrides[fidx].count(argument) > 0; }
-    inline uint32_t getMockedValue(uint32_t fidx, uint32_t argument) { return overrides[fidx][argument]; }
+    inline bool isMocked(uint32_t fidx, uint32_t argument) {
+        return overrides.count(fidx) > 0 && overrides[fidx].count(argument) > 0;
+    }
+    inline uint32_t getMockedValue(uint32_t fidx, uint32_t argument) {
+        return overrides[fidx][argument];
+    }
 
     void addOverride(Module *m, uint8_t *interruptData);
     void removeOverride(Module *m, uint8_t *interruptData);

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -291,7 +291,8 @@ bool i_instr_call(Module *m) {
         if (m->sp >= 0) {
             uint32_t arg = m->stack[m->sp].value.uint32;
             if (m->warduino->debugger->isMocked(fidx, arg)) {
-                m->stack[m->sp].value.uint32 = m->warduino->debugger->getMockedValue(fidx, arg);
+                m->stack[m->sp].value.uint32 =
+                    m->warduino->debugger->getMockedValue(fidx, arg);
                 return true;
             }
         }

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -287,6 +287,17 @@ bool i_instr_call(Module *m) {
     }
 
     if (fidx < m->import_count) {
+        // Mocking only works on primitives, no need to check for it otherwise.
+        if (m->sp >= 0) {
+            printf("Call primitive with arguments on the stack %s.\n", m->functions[fidx].import_field);
+            uint32_t arg = m->stack[m->sp].value.uint32;
+            if (m->warduino->debugger->isMocked(fidx, arg)) {
+                printf("Put result on the stack for arg %d %d\n", arg, m->warduino->debugger->getMockedValue(fidx, arg));
+                m->stack[m->sp].value.uint32 = m->warduino->debugger->getMockedValue(fidx, arg);
+                return true;
+            }
+        }
+
         return ((Primitive)m->functions[fidx].func_ptr)(m);
     } else {
         if (m->csp >= CALLSTACK_SIZE) {

--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -289,10 +289,8 @@ bool i_instr_call(Module *m) {
     if (fidx < m->import_count) {
         // Mocking only works on primitives, no need to check for it otherwise.
         if (m->sp >= 0) {
-            printf("Call primitive with arguments on the stack %s.\n", m->functions[fidx].import_field);
             uint32_t arg = m->stack[m->sp].value.uint32;
             if (m->warduino->debugger->isMocked(fidx, arg)) {
-                printf("Put result on the stack for arg %d %d\n", arg, m->warduino->debugger->getMockedValue(fidx, arg));
                 m->stack[m->sp].value.uint32 = m->warduino->debugger->getMockedValue(fidx, arg);
                 return true;
             }


### PR DESCRIPTION
Adds the primitive mocking debugging interrupts that make it possible to set the return value for a primitive with one argument. Mocked primitives are also visible in the snapshots so that restoring a snapshot from the past also removes any primitives mocked using future values.