### PR TITLE
Fix DEBUG mode, include in zephyr primitives and typo

### DIFF
--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -153,7 +153,7 @@ int prim_index = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("pim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                              \
         }                                                                  \
     }
 

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -153,7 +153,7 @@ int prim_index = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("prim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                             \
         }                                                                  \
     }
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -462,7 +462,7 @@ def_prim(write_spi_bytes_16, twoToNoneU32) {
 def_prim(subscribe_interrupt, threeToNoneU32) {
     uint8_t pin = arg2.uint32;   // GPIOPin
     uint8_t tidx = arg1.uint32;  // Table Idx pointing to Callback function
-    // uint8_t mode = arg0.uint32; // never used in emulator
+    [[maybe_unused]] uint8_t mode = arg0.uint32; // never used in emulator
 
     debug("EMU: subscribe_interrupt(%u, %u, %u) \n", pin, tidx, mode);
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -50,7 +50,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("pim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                              \
         }                                                                  \
     }
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -50,7 +50,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("prim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                             \
         }                                                                  \
     }
 
@@ -394,7 +394,7 @@ def_prim(chip_pin_mode, twoToNoneU32) {
 }
 
 def_prim(chip_digital_write, twoToNoneU32) {
-    debug("EMU: chip_digital_write(%u,%u) \n", arg1.uint32, arg0.uint32);
+    printf("EMU: chip_digital_write(%u,%u) \n", arg1.uint32, arg0.uint32);
     pop_args(2);
     return true;
 }
@@ -462,7 +462,8 @@ def_prim(write_spi_bytes_16, twoToNoneU32) {
 def_prim(subscribe_interrupt, threeToNoneU32) {
     uint8_t pin = arg2.uint32;   // GPIOPin
     uint8_t tidx = arg1.uint32;  // Table Idx pointing to Callback function
-    [[maybe_unused]] uint8_t mode = arg0.uint32; // Not used by emulator only printed
+    [[maybe_unused]] uint8_t mode =
+        arg0.uint32;  // Not used by emulator only printed
 
     debug("EMU: subscribe_interrupt(%u, %u, %u) \n", pin, tidx, mode);
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -462,7 +462,7 @@ def_prim(write_spi_bytes_16, twoToNoneU32) {
 def_prim(subscribe_interrupt, threeToNoneU32) {
     uint8_t pin = arg2.uint32;   // GPIOPin
     uint8_t tidx = arg1.uint32;  // Table Idx pointing to Callback function
-    [[maybe_unused]] uint8_t mode = arg0.uint32; // never used in emulator
+    [[maybe_unused]] uint8_t mode = arg0.uint32; // Not used by emulator only printed
 
     debug("EMU: subscribe_interrupt(%u, %u, %u) \n", pin, tidx, mode);
 

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -51,7 +51,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("prim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                             \
         }                                                                  \
     }
 

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -51,7 +51,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("pim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                              \
         }                                                                  \
     }
 

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -53,7 +53,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("pim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                              \
         }                                                                  \
     }
 

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -53,7 +53,7 @@ double sensor_emu = 0;
             p->f_reverse = nullptr;                                        \
             p->f_serialize_state = nullptr;                                \
         } else {                                                           \
-            FATAL("prim_index out of bounds");                              \
+            FATAL("prim_index out of bounds");                             \
         }                                                                  \
     }
 

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -1,4 +1,3 @@
-#include <sys/_stdint.h>
 #ifndef ARDUINO
 
 /**

--- a/tests/unit/shared/serialisation.h
+++ b/tests/unit/shared/serialisation.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <iostream>
 
 class Serialiser {


### PR DESCRIPTION
Very minor fixes that are useful when using a newer zephyr version or when wanting to use the DEBUG flag on the emulator.

Also fixes the unit tests not compiling on ubuntu due to a missing `cstdint` include.