### PR TITLE
Fix tableidx overflow on call_indirect

### DIFF
--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -317,7 +317,7 @@ bool i_instr_call(Module *m) {
 bool i_instr_call_indirect(Module *m) {
     uint32_t tidx = read_LEB_32(&m->pc_ptr);  // TODO: use tidx?
     (void)tidx;
-    read_LEB(&m->pc_ptr, 1);  // reserved immediate
+    read_LEB_32(&m->pc_ptr);  // reserved immediate
     uint32_t val = m->stack[m->sp--].value.uint32;
     if (m->options.mangle_table_index) {
         // val is the table address + the index (not sized for the

--- a/src/Interpreter/interpreter.cpp
+++ b/src/Interpreter/interpreter.cpp
@@ -98,6 +98,12 @@ void Interpreter::setup_call(Module *m, uint32_t fidx) {
     // Push function locals
     for (uint32_t lidx = 0; lidx < func->local_count; lidx++) {
         m->sp += 1;
+#if DEBUG || TRACE || WARN || INFO
+        if (m->sp >= STACK_SIZE) {
+            FATAL("Stack overflow m->sp = %d, STACK_SIZE = %d\n", m->sp,
+                  STACK_SIZE);
+        }
+#endif
         m->stack[m->sp].value_type = func->local_value_type[lidx];
         m->stack[m->sp].value = {0};  // Initialize whole union to 0
     }

--- a/src/Interpreter/interpreter.cpp
+++ b/src/Interpreter/interpreter.cpp
@@ -100,8 +100,8 @@ void Interpreter::setup_call(Module *m, uint32_t fidx) {
         m->sp += 1;
 #if DEBUG || TRACE || WARN || INFO
         if (m->sp >= STACK_SIZE) {
-            FATAL("Stack overflow m->sp = %d, STACK_SIZE = %d\n", m->sp,
-                  STACK_SIZE);
+            FATAL("WebAssembly stack overflow m->sp = %d, STACK_SIZE = %d\n",
+                  m->sp, STACK_SIZE);
         }
 #endif
         m->stack[m->sp].value_type = func->local_value_type[lidx];

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -159,7 +159,7 @@ void skip_immediates(uint8_t **pos) {
         case 0x11:  // call_indirect
             // encoding: 0x11 x 0x00
             read_LEB_32(pos);  // read x
-            read_LEB(pos, 7);  // 0x00 byte
+            read_LEB_32(pos);  // 0x00 byte
             break;
             // varint64
         case 0x42:  // i64.const


### PR DESCRIPTION
On some programs, the vm can run into an error like this `Unsigned LEB at byte 0x12800b011 overflow`. This overflow occurs when reading table indexes on the `call_indirect` function. It occurs because the table index in WARDuino can at most consist of 7 or 1 bits (the maximum amount of bit differs in two parts of the vm). In the wasm specification however, the table index is specified to be a u32. You would expect this error to only occur on modules using multiple tables but as it turns out this also happens on rust binaries that use just a single table. The reason for this is that the rust compiler can sometimes use a 5 byte table index `0x80 0x80 0x80 0x80 0x00` to encode table index 0 as described in [this](https://blog.rust-lang.org/2024/09/24/webassembly-targets-change-in-default-target-features.html) blog post. Any binary using such an index will fail to execute, this PR fixes that.

This PR also adds an error message for stack overflows during `setup_call` when in debug/trace/warn/info mode. This way users attempting to run bigger programs will more quickly realize that they just need to increase the stack size (or run their program in release mode) and it's not an issue with the vm implementation.