### PR TITLE
CI: Remove Ubuntu 20.04

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,7 +26,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-latest]
+                os: [ubuntu-22.04, ubuntu-24.04, macos-latest]
         steps:
             - name: Checkout
               uses: actions/checkout@v4


### PR DESCRIPTION
The Ubuntu 20.04 action is failing since Ubuntu 20.04 has been deprecated, this PR removes it from the list of operating systems.

[more info](https://github.com/actions/runner-images/issues/11101)