### PR TITLE
fix: make a checkpoint when hitting a breakpoint

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -144,6 +144,9 @@ bool Debugger::isBreakpoint(uint8_t *loc) {
 }
 
 void Debugger::notifyBreakpoint(Module *m, uint8_t *pc_ptr) {
+    if (snapshotPolicy == SnapshotPolicy::checkpointing) {
+        checkpoint(m);
+    }
     this->mark = nullptr;
     const uint32_t bp = toVirtualAddress(pc_ptr, m);
     this->channel->write("AT %" PRIu32 "!\n", bp);


### PR DESCRIPTION
This PR makes breakpoint AT messages create an automatic checkpoint.

This also means that step over will now result in a checkpoint telling the debugger how many instructions it stepped over.