### PR TITLE
Print emulator pin state after chip_digital_write

### DIFF
--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -411,6 +411,15 @@ def_prim(chip_digital_write, twoToNoneU32) {
     if (writable) {
         PINS[pin] = val;
     }
+    printf("EMU: ");
+    for (int i = 0; i < NUM_DIGITAL_PINS / 2; i++) {
+        printf("%d ", PINS[i]);
+    }
+    printf("\nEMU: ");
+    for (int i = NUM_DIGITAL_PINS / 2; i < NUM_DIGITAL_PINS; i++) {
+        printf("%d ", PINS[i]);
+    }
+    printf("\n");
     pop_args(2);
     return writable;
 }


### PR DESCRIPTION
This PR makes the emulator print the current pin state for digital writes to stdout.

Example:
```
EMU: chip_digital_write(12,0) 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
EMU: chip_digital_write(13,1) 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
```