### PR TITLE
Fix millis on the emulator incorrectly converting the microseconds

### DIFF
--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -246,9 +246,9 @@ def_prim(abort, NoneToNoneU32) {
 }
 
 def_prim(millis, NoneToOneU64) {
-    struct timeval tv{};
+    timeval tv {};
     gettimeofday(&tv, nullptr);
-    unsigned long millis = 1000 * tv.tv_sec + tv.tv_usec;
+    const uint64_t millis = 1000 * tv.tv_sec + tv.tv_usec/1000;
     pushUInt64(millis);
     return true;
 }

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -246,9 +246,9 @@ def_prim(abort, NoneToNoneU32) {
 }
 
 def_prim(millis, NoneToOneU64) {
-    timeval tv {};
+    timeval tv{};
     gettimeofday(&tv, nullptr);
-    const uint64_t millis = 1000 * tv.tv_sec + tv.tv_usec/1000;
+    const uint64_t millis = 1000 * tv.tv_sec + tv.tv_usec / 1000;
     pushUInt64(millis);
     return true;
 }


### PR DESCRIPTION
The microseconds should be divided by 1000 to get the number of milliseconds.