### PR TITLE
Cardputer display

### DIFF
--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -208,6 +208,7 @@ uint32_t param_I32_arr_len1[1] = {I32};
 uint32_t param_I32_arr_len2[2] = {I32, I32};
 uint32_t param_I32_arr_len3[3] = {I32, I32, I32};
 uint32_t param_I32_arr_len4[4] = {I32, I32, I32, I32};
+uint32_t param_I32_arr_len5[5] = {I32, I32, I32, I32, I32};
 uint32_t param_I32_arr_len10[10] = {I32, I32, I32, I32, I32,
                                     I32, I32, I32, I32, I32};
 
@@ -970,7 +971,7 @@ int32_t http_post_request(Module *m, const String url, const String body,
 
 // Cardputer display
 def_prim(display_setup, NoneToNoneU32) {
-    setup();
+    displaySetup();
     return true;
 }
 
@@ -996,7 +997,7 @@ def_prim(display_fillrect, fiveToNoneI32) {
     return true;
 }
 
-def_prim(display_fillcircle, fourToNoneI32) {
+def_prim(display_fillcircle, fourToNoneU32) {
     uint32_t color = arg3.uint32;
     int32_t radius = arg2.int32;
     int32_t y = arg1.int32;

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -25,6 +25,9 @@
 #include "../WARDuino/CallbackHandler.h"
 #include "primitives.h"
 
+// M5stack
+#include "m5stack/display.h"
+
 // NEOPIXEL
 #include <Adafruit_NeoPixel.h>
 #define PIN 33
@@ -132,7 +135,7 @@ int resolve_isr(int pin) {
 // Primitives
 
 #define NUM_PRIMITIVES 0
-#define NUM_PRIMITIVES_ARDUINO 39
+#define NUM_PRIMITIVES_ARDUINO 44
 
 #define ALL_PRIMITIVES (NUM_PRIMITIVES + NUM_PRIMITIVES_ARDUINO)
 
@@ -245,6 +248,15 @@ Type fourToNoneU32 = {
     .results = nullptr,
     .mask =
         0x8001111 /* 0x800 = no return ; 1 = I32; 1 = I32; 1 = I32; 1 = I32*/
+};
+
+Type fiveToNoneI32 = {
+    .form = FUNC,
+    .param_count = 5,
+    .params = param_I32_arr_len5,
+    .result_count = 0,
+    .results = nullptr,
+    .mask = 0x80011111
 };
 
 Type oneToOneU32 = {
@@ -956,6 +968,44 @@ int32_t http_post_request(Module *m, const String url, const String body,
     return httpResponseCode;
 }
 
+// Cardputer display
+def_prim(display_setup, NoneToNoneU32) {
+    setup();
+    return true;
+}
+
+def_prim(display_width, NoneToOneU32) {
+    pushInt32(width());
+    return true;
+}
+
+def_prim(display_height, NoneToOneU32) {
+    pushInt32(height());
+    return true;
+}
+
+
+def_prim(display_fillrect, fiveToNoneI32) {
+    uint32_t color = arg4.uint32;
+    int32_t height = arg3.int32;
+    int32_t width = arg2.int32;
+    int32_t y = arg1.int32;
+    int32_t x = arg0.int32;
+    fillRect(x, y, width, height, color);
+    pop_args(5);
+    return true;
+}
+
+def_prim(display_fillcircle, fourToNoneI32) {
+    uint32_t color = arg3.uint32;
+    int32_t radius = arg2.int32;
+    int32_t y = arg1.int32;
+    int32_t x = arg0.int32;
+    fillCircle(x, y, radius, color);
+    pop_args(5);
+    return true;
+}
+
 //------------------------------------------------------
 // Installing all the primitives & ISRs
 //------------------------------------------------------
@@ -1039,6 +1089,12 @@ void install_primitives() {
     install_primitive(chip_analog_write);
     install_primitive(chip_ledc_attach);
     install_primitive(chip_ledc_set_duty);
+
+    install_primitive(display_setup);
+    install_primitive(display_width);
+    install_primitive(display_height);
+    install_primitive(display_fillrect);
+    install_primitive(display_fillcircle);
 
     dbg_info("INSTALLING ISRs\n");
     install_isrs();

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -366,8 +366,8 @@ def_prim(micros, NoneToOneU64) {
     return true;
 }
 
-def_prim(rand, NoneToOneU32) {
-    pushInt32(rand());
+def_prim(int_random, NoneToOneU32) {
+    pushInt32(random(6000));
     return true;
 }
 
@@ -1044,7 +1044,7 @@ void install_primitives() {
     install_primitive(abort);
     install_primitive(millis);
     install_primitive(micros);
-    install_primitive(rand);
+    install_primitive(int_random);
 
     install_primitive(print_int);
     install_primitive(print_string);

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -132,7 +132,7 @@ int resolve_isr(int pin) {
 // Primitives
 
 #define NUM_PRIMITIVES 0
-#define NUM_PRIMITIVES_ARDUINO 38
+#define NUM_PRIMITIVES_ARDUINO 39
 
 #define ALL_PRIMITIVES (NUM_PRIMITIVES + NUM_PRIMITIVES_ARDUINO)
 
@@ -350,6 +350,11 @@ def_prim(millis, NoneToOneU32) {
 
 def_prim(micros, NoneToOneU64) {
     pushUInt64(micros());
+    return true;
+}
+
+def_prim(rand, NoneToOneU32) {
+    pushInt32(rand());
     return true;
 }
 
@@ -988,6 +993,7 @@ void install_primitives() {
     install_primitive(abort);
     install_primitive(millis);
     install_primitive(micros);
+    install_primitive(rand);
 
     install_primitive(print_int);
     install_primitive(print_string);

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -103,6 +103,7 @@ uint32_t param_I32_arr_len1[1] = {I32};
 uint32_t param_I32_arr_len2[2] = {I32, I32};
 uint32_t param_I32_arr_len3[3] = {I32, I32, I32};
 uint32_t param_I32_arr_len4[4] = {I32, I32, I32, I32};
+uint32_t param_I32_arr_len5[5] = {I32, I32, I32, I32, I32};
 uint32_t param_I32_arr_len10[10] = {I32, I32, I32, I32, I32,
                                     I32, I32, I32, I32, I32};
 

--- a/src/Primitives/m5stack/display.cpp
+++ b/src/Primitives/m5stack/display.cpp
@@ -1,0 +1,23 @@
+#include "display.h"
+#include "M5Cardputer.h"
+
+void setup() {
+    auto cfg = M5.config();
+    M5Cardputer.begin(cfg);
+}
+
+int width() {
+    return M5Cardputer.Display.width();
+}
+
+int height() {
+    return M5Cardputer.Display.height();
+}
+
+void fillRect(int x, int y, int w, int h, uint32_t color) {
+    M5Cardputer.Display.fillRect(x, y, w, h, color);
+}
+
+void fillCircle(int x, int y, int radius, uint32_t color) {
+    M5Cardputer.Display.fillCircle(x, y, radius, color);
+}

--- a/src/Primitives/m5stack/display.cpp
+++ b/src/Primitives/m5stack/display.cpp
@@ -1,7 +1,7 @@
 #include "display.h"
 #include "M5Cardputer.h"
 
-void setup() {
+void displaySetup() {
     auto cfg = M5.config();
     M5Cardputer.begin(cfg);
 }

--- a/src/Primitives/m5stack/display.h
+++ b/src/Primitives/m5stack/display.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// port of the Graphics library for M5Stack series
+// https://github.com/m5stack/M5GFX
+
+void setup();
+
+int width();
+
+int height();
+
+void fillRect(int x, int y, int w, int h, uint32_t color);
+
+void fillCircle(int x, int y, int radius, uint32_t color);

--- a/src/Primitives/m5stack/display.h
+++ b/src/Primitives/m5stack/display.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <cstdint>
+
 // port of the Graphics library for M5Stack series
 // https://github.com/m5stack/M5GFX
 
-void setup();
+void displaySetup();
 
 int width();
 

--- a/tutorials/wat/main/cardputer.wat
+++ b/tutorials/wat/main/cardputer.wat
@@ -10,7 +10,7 @@
   ;; Imports from the WARDuino VM
   (import "env" "display_setup" (func $env.setup (type $void->void)))
   (import "env" "display_width" (func $env.width (type $void->int32)))
-  (import "env" "rand" (func $env.rand (type $void->int32)))
+  (import "env" "int_random" (func $env.rand (type $void->int32)))
   (import "env" "display_height" (func $env.height (type $void->int32)))
   (import "env" "display_fillrect" (func $env.fillrect (type $int32->i32->i32->i32->i32->void)))
   (import "env" "display_fillcircle" (func $env.fillcircle (type $int32->int32->i32->i32->void)))

--- a/tutorials/wat/main/cardputer.wat
+++ b/tutorials/wat/main/cardputer.wat
@@ -1,0 +1,73 @@
+;; WARDuino port of M5stack cardputer Basic Display example
+;; https://github.com/m5stack/M5Cardputer/blob/master/examples/Basic/display/display.ino
+(module
+  ;; Type declarations
+  (type $int32->int32->i32->i32->void (func (param i32 i32 i32 i32)))
+  (type $int32->i32->i32->i32->i32->void (func (param i32 i32 i32 i32 i32)))
+  (type $void->int32 (func (result i32)))
+  (type $void->void (func))
+
+  ;; Imports from the WARDuino VM
+  (import "env" "display_setup" (func $env.setup (type $void->void)))
+  (import "env" "display_width" (func $env.width (type $void->int32)))
+  (import "env" "rand" (func $env.rand (type $void->int32)))
+  (import "env" "display_height" (func $env.height (type $void->int32)))
+  (import "env" "display_fillrect" (func $env.fillrect (type $int32->i32->i32->i32->i32->void)))
+  (import "env" "display_fillcircle" (func $env.fillcircle (type $int32->int32->i32->i32->void)))
+
+  ;; chaos function (public)
+  (func $chaos (type $void->void)
+    (local $x i32)
+    (local $y i32)
+    (local $r i32)
+
+    ;; Initialise
+    call $env.setup
+
+    ;; Update display in infinite loop
+    loop $infinite
+        ;;    int x      = rand() % M5Cardputer.Display.width();
+        call $env.rand
+        call $env.width
+        i32.rem_u
+        local.set $x
+        ;;    int y      = rand() % M5Cardputer.Display.height();
+        call $env.rand
+        call $env.height
+        i32.rem_u
+        local.set $y
+        ;;    int r      = (M5Cardputer.Display.width() >> 4) + 2;
+        call $env.width
+        i32.const 4
+        i32.shr_s
+        i32.const 2
+        i32.add
+        local.set $r
+        ;;    M5Cardputer.Display.fillCircle(x, y, r, c);
+        local.get $x
+        local.get $y
+        local.get $r
+        call $env.rand
+        call $env.fillcircle
+        ;;    int x      = rand() % M5Cardputer.Display.width();
+        call $env.rand
+        call $env.width
+        i32.rem_u
+        local.set $x
+        ;;    int y      = rand() % M5Cardputer.Display.height();
+        call $env.rand
+        call $env.height
+        i32.rem_u
+        local.set $y
+        ;;    M5Cardputer.Display.fillRectangle(x, y, w, h, c);
+        local.get $x
+        local.get $y
+        local.get $r
+        local.get $r
+        call $env.rand
+        call $env.fillrect
+    br $infinite                   ;; jump back to start of loop
+    end)
+
+  ;; Export chaos as function
+  (export "main" (func $chaos)))


### PR DESCRIPTION
## Cardputer display hardware support

The M5stack cardputer built-in display can be controlled with the M5Cardputer library.

- [x] This PR ports the display functions to WARDuino, needed for the [Basic example](https://github.com/m5stack/M5Cardputer/blob/master/examples/Basic/display/display.ino).
- [x] This includes a new `random` primitive for Arduino.

**hardware:** https://docs.m5stack.com/en/core/Cardputer
**library:** https://docs.arduino.cc/libraries/m5cardputer/
**example:** https://github.com/m5stack/M5Cardputer/blob/master/examples/Basic/display/display.ino