### PR TITLE
Ignore comments in latch spectest assertions parser

### DIFF
--- a/tests/latch/src/util/spec.util.ts
+++ b/tests/latch/src/util/spec.util.ts
@@ -77,10 +77,14 @@ function consume(input: string, cursor: number, regex: RegExp = / /d): number {
     return (match?.indices[0][1]) ?? 0;
 }
 
+function shouldParseLine(input: string): boolean {
+    return input.includes('(assert_return') && !input.replace(/\s+/g, '').startsWith(';;');
+}
+
 export function parseAsserts(file: string): string[] {
     const asserts: string[] = [];
     readFileSync(file).toString().split('\n').forEach((line) => {
-        if (line.includes('(assert_return')) {
+        if (shouldParseLine(line)) {
             asserts.push(line.replace(/.*\(assert_return\s*/, '('));
         }
     });


### PR DESCRIPTION
Commented out assertions in the latch spectests were still parsed and executed.
It might however be useful to have the possibility to include test assertions that are ignored when running the tests, for example, to demonstrate that these tests would currently fail but should succeed and be included eventually.
Therefore, this PR ensures commented out assertions are ignored when running the spectests.