### PR TITLE
Fix compilation errors when using logging with the new globals

### DIFF
--- a/src/Interpreter/instructions.cpp
+++ b/src/Interpreter/instructions.cpp
@@ -459,7 +459,8 @@ bool i_instr_tee_local(Module *m) {
 bool i_instr_get_global(Module *m) {
     int32_t arg = read_LEB_32(&m->pc_ptr);
 #if TRACE
-    debug("      - arg: 0x%x, got %s\n", arg, value_repr(m->globals[arg]));
+    debug("      - arg: 0x%x, got %s\n", arg,
+          value_repr(m->globals[arg]->value));
 #endif
     m->stack[++m->sp] = *m->globals[arg]->value;
     return true;

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -567,7 +567,7 @@ void WARDuino::instantiate_module(Module *m, uint8_t *bytes,
                                 "    setting global %d (content_type %d) to "
                                 "%p: %s\n",
                                 m->global_count - 1, content_type, val,
-                                value_repr(*glob));
+                                value_repr((*glob)->value));
                             break;
                         }
                         default:


### PR DESCRIPTION
In some cases, `value_repr` is called on `Global` struct pointers instead of `StackValue` pointers, causing a compilation error when enabling logging. This PR fixes that by getting the associated `StackValue` pointer from the global.