### PR TITLE
Send checkpoints when stepping or pausing in trace mode

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1610,10 +1610,11 @@ bool Debugger::handleUpdateStackValue(const Module *m, uint8_t *bytes) const {
     return true;
 }
 
-bool Debugger::reset(Module *m) const {
+bool Debugger::reset(Module *m) {
     auto *wasm =
         static_cast<uint8_t *>(malloc(sizeof(uint8_t) * m->byte_count));
     memcpy(wasm, m->bytes, m->byte_count);
+    instructions_executed = 0;
     m->warduino->update_module(m, wasm, m->byte_count);
     this->channel->write("Reset WARDuino.\n");
     return true;

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1024,7 +1024,16 @@ void Debugger::handleSnapshotPolicy(Module *m) {
         this->channel->write("\n");
     } else if (snapshotPolicy == SnapshotPolicy::checkpointing) {
         if (instructions_executed >= checkpointInterval || fidx_called) {
-            checkpoint(m);
+            if (min_return_values == 0) {
+                checkpoint(m);
+            } else {
+                if (fidx_called) {
+                    const Type *type = m->functions[*fidx_called].type;
+                    if (type->result_count >= min_return_values) {
+                        checkpoint(m);
+                    }
+                }
+            }
         }
         instructions_executed++;
 
@@ -1044,19 +1053,6 @@ void Debugger::handleSnapshotPolicy(Module *m) {
 void Debugger::checkpoint(Module *m, const bool force) {
     if (instructions_executed == 0 && !force) {
         return;
-    }
-
-    if (min_return_values != 0) {
-        if (!fidx_called) {
-            // Tracing mode is on, but no primitive was called.
-            return;
-        }
-
-        const Type *type = m->functions[*fidx_called].type;
-        if (type->result_count < min_return_values) {
-            // Primitive was called but did not have the required return values.
-            return;
-        }
     }
 
     this->channel->write(R"(CHECKPOINT {"instructions_executed": %d, )",

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -201,7 +201,7 @@ class Debugger {
 
     bool handleUpdateStackValue(const Module *m, uint8_t *bytes) const;
 
-    bool reset(Module *m) const;
+    bool reset(Module *m);
 
     //// Handle out-of-place debugging
 


### PR DESCRIPTION
This works better for debuggers such as MIO which expect information about the current program counter/program state while stepping.

Also now resets the instruction counter upon using `reset` in the debugger so this no loner happens:
```
CHECKPOINT {"instructions_executed": 17, "fidx_called": 1, "args": [21], "returns": [-2], "snapshot": {"pc":241}}
EMU: chip_digital_write(10,0) 
EMU: 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
EMU: chip_digital_write(11,1) 
EMU: 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
EMU: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 
Interrupt: 13
Reset WARDuino.
04
Interrupt: 4
CHECKPOINT {"instructions_executed": 13, "snapshot": {"pc":213}}
STEP!
```
Here we reset and then execute one instruction but say we executed 13. This should now be resolved.