### PR TITLE
Explicitly set clang-format PointerAlignment

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 BasedOnStyle: Google
 IndentWidth: 4
+PointerAlignment: Right


### PR DESCRIPTION
It seems a recent clang-format change causes pointers to sometimes be left aligned while all our code uses right aligned pointers. This PR enforces right alignment at all times. Because of this change I would often have clang-format change the pointer alignment locally which then caused the CI to fail, this is now resolved.

```
16:32:20 ~/Projects/WARDuino fix/clang-format-pointer-alignment $ clang-format --style=google --dump-config | egrep Pointer
  AlignFunctionPointers: false
  AlignFunctionPointers: false
  AlignFunctionPointers: false
  AlignFunctionPointers: false
  AlignFunctionPointers: false
  AlignFunctionPointers: false
  AlignFunctionPointers: false
DerivePointerAlignment: false
PointerAlignment: Left                  <- Is now Left instead of Right
ReferenceAlignment: Pointer
SpaceAroundPointerQualifiers: Default
```