### PR TITLE
Fix Global initialization and designators order in def_glob macro

### DIFF
--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -134,10 +134,13 @@ int resolve_isr(int pin) {
 
 int global_index = 0;
 
-#define def_glob(name, type, mut, init_value)             \
-    StackValue name##_sv{.value_type = type, init_value}; \
-    Global name = {                                       \
-        .mutability = mut, .import_field = #name, .value = &name##_sv};
+#define def_glob(name, type, mut, init_val)                           \
+    StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
+    Global name##_g = {.export_name = nullptr,                        \
+                       .import_module = nullptr,                      \
+                       .import_field = #name,                         \
+                       .mutability = mut,                             \
+                       .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -136,11 +136,11 @@ int global_index = 0;
 
 #define def_glob(name, type, mut, init_val)                           \
     StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
-    Global name##_g = {.export_name = nullptr,                        \
-                       .import_module = nullptr,                      \
-                       .import_field = #name,                         \
-                       .mutability = mut,                             \
-                       .value = &name##_sv};
+    Global name = {.export_name = nullptr,                            \
+                   .import_module = nullptr,                          \
+                   .import_field = #name,                             \
+                   .mutability = mut,                                 \
+                   .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -35,11 +35,11 @@ double sensor_emu = 0;
 
 #define def_glob(name, type, mut, init_val)                           \
     StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
-    Global name##_g = {.export_name = nullptr,                        \
-                       .import_module = nullptr,                      \
-                       .import_field = #name,                         \
-                       .mutability = mut,                             \
-                       .value = &name##_sv};
+    Global name = {.export_name = nullptr,                            \
+                   .import_module = nullptr,                          \
+                   .import_field = #name,                             \
+                   .mutability = mut,                                 \
+                   .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -33,10 +33,13 @@ int global_index = 0;
 
 double sensor_emu = 0;
 
-#define def_glob(name, type, mut, init_value)             \
-    StackValue name##_sv{.value_type = type, init_value}; \
-    Global name = {                                       \
-        .mutability = mut, .import_field = #name, .value = &name##_sv};
+#define def_glob(name, type, mut, init_val)                           \
+    StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
+    Global name##_g = {.export_name = nullptr,                        \
+                       .import_module = nullptr,                      \
+                       .import_field = #name,                         \
+                       .mutability = mut,                             \
+                       .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -32,10 +32,13 @@
 
 int global_index = 0;
 
-#define def_glob(name, type, mut, init_value)             \
-    StackValue name##_sv{.value_type = type, init_value}; \
-    Global name = {                                       \
-        .mutability = mut, .import_field = #name, .value = &name##_sv};
+#define def_glob(name, type, mut, init_val)                           \
+    StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
+    Global name##_g = {.export_name = nullptr,                        \
+                       .import_module = nullptr,                      \
+                       .import_field = #name,                         \
+                       .mutability = mut,                             \
+                       .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -34,11 +34,11 @@ int global_index = 0;
 
 #define def_glob(name, type, mut, init_val)                           \
     StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
-    Global name##_g = {.export_name = nullptr,                        \
-                       .import_module = nullptr,                      \
-                       .import_field = #name,                         \
-                       .mutability = mut,                             \
-                       .value = &name##_sv};
+    Global name = {.export_name = nullptr,                            \
+                   .import_module = nullptr,                          \
+                   .import_field = #name,                             \
+                   .mutability = mut,                                 \
+                   .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -40,10 +40,13 @@
 
 int global_index = 0;
 
-#define def_glob(name, type, mut, init_value)             \
-    StackValue name##_sv{.value_type = type, init_value}; \
-    Global name = {                                       \
-        .mutability = mut, .import_field = #name, .value = &name##_sv};
+#define def_glob(name, type, mut, init_val)                           \
+    StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
+    Global name##_g = {.export_name = nullptr,                        \
+                       .import_module = nullptr,                      \
+                       .import_field = #name,                         \
+                       .mutability = mut,                             \
+                       .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -42,11 +42,11 @@ int global_index = 0;
 
 #define def_glob(name, type, mut, init_val)                           \
     StackValue name##_sv = {.value_type = type, .value = {init_val}}; \
-    Global name##_g = {.export_name = nullptr,                        \
-                       .import_module = nullptr,                      \
-                       .import_field = #name,                         \
-                       .mutability = mut,                             \
-                       .value = &name##_sv};
+    Global name = {.export_name = nullptr,                            \
+                   .import_module = nullptr,                          \
+                   .import_field = #name,                             \
+                   .mutability = mut,                                 \
+                   .value = &name##_sv};
 
 #define install_global(global_name)                        \
     {                                                      \

--- a/src/WARDuino/internals.h
+++ b/src/WARDuino/internals.h
@@ -112,11 +112,11 @@ typedef struct Memory {
 } Memory;
 
 typedef struct Global {
-    char *export_name;    // export name of the global
-    char *import_module;  // import module name
-    char *import_field;   // import field name
-    bool mutability;      // 0: immutable, 1: mutable
-    StackValue *value;    // current value
+    char *export_name;         // export name of the global
+    char *import_module;       // import module name
+    const char *import_field;  // import field name
+    bool mutability;           // 0: immutable, 1: mutable
+    StackValue *value;         // current value
 } Global;
 
 typedef struct Options {


### PR DESCRIPTION
Closes #357.

The `def_glob` macros of all platforms don't correctly initialize the Global struct, resulting in a compiler error and breaking CI when globals are defined:
- the previous `StackValue` initialization used a combination of designated (`.value_type = ...`) and positional initializers, which is invalid
- fields in the `Global` struct were initialized out of declaration order
- some fields of the `Global` Struct (`export_name`, `import_module`) were not initialized

This PR fixes these issues.