### PR TITLE
Add interrupt masking primitives

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -653,8 +653,9 @@ void Debugger::dumpEvents(long start, long size) const {
                   CallbackHandler::event_begin() + end,
                   [this, &index, &end](const Event &e) {
                       this->channel->write(
-                          R"({"topic": "%s", "payload": "%s"})",
-                          e.topic.c_str(), e.payload.c_str());
+                          R"({"topic": "%s", "group": %d, "payload": "%s"})",
+                          e.topic.c_str(), static_cast<int>(e.group),
+                          e.payload.c_str());
                       if (++index < end) {
                           this->channel->write(", ");
                       }
@@ -1410,6 +1411,10 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                     topic[topicSize] = '\0';
                     program_state += topicSize;
 
+                    // read group
+                    uint8_t group_idx = read_B32(&program_state);
+                    EventGroup group = static_cast<EventGroup>(group_idx);
+
                     // read payload
                     uint32_t payloadSize = read_B32(&program_state);
                     auto *payload =
@@ -1418,9 +1423,8 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                     payload[payloadSize] = '\0';
                     program_state += payloadSize;
 
-                    CallbackHandler::push_event(
-                        topic, EventGroup::DEBUGGER,  // TODO: fix group !!!!!
-                        payload, payloadSize);
+                    CallbackHandler::push_event(topic, group, payload,
+                                                payloadSize);
                     free(topic);
                 }
                 break;

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -769,7 +769,8 @@ bool Debugger::handlePushedEvent(char *bytes) const {
     if (*bytes != interruptPUSHEvent) return false;
     auto parsed = nlohmann::json::parse(bytes + 1);
     debug("handle pushed event: %s\n", bytes + 1);
-    auto *event = new Event(*parsed.find("topic"), *parsed.find("payload"));
+    auto *event = new Event(*parsed.find("topic"), *parsed.find("group"),
+                            *parsed.find("payload"));
     CallbackHandler::push_event(event);
     this->notifyPushedEvent();
     return true;
@@ -1417,7 +1418,9 @@ bool Debugger::saveState(Module *m, uint8_t *interruptData) {
                     payload[payloadSize] = '\0';
                     program_state += payloadSize;
 
-                    CallbackHandler::push_event(topic, payload, payloadSize);
+                    CallbackHandler::push_event(
+                        topic, EventGroup::DEBUGGER,  // TODO: fix group !!!!!
+                        payload, payloadSize);
                     free(topic);
                 }
                 break;

--- a/src/Edward/proxy_supervisor.cpp
+++ b/src/Edward/proxy_supervisor.cpp
@@ -50,7 +50,7 @@ Event *parseJSON(char *buff) {
     nlohmann::basic_json<> parsed = nlohmann::json::parse(buff);
     printf("parseJSON: %s\n", parsed.dump().c_str());
     std::string payload = *parsed.find("payload");
-    return new Event(*parsed.find("topic"), payload);
+    return new Event(*parsed.find("topic"), *parsed.find("group"), payload);
 }
 
 ProxySupervisor::ProxySupervisor(Channel *duplex, warduino::mutex *mutex) {
@@ -106,8 +106,9 @@ void ProxySupervisor::listenToSocket() {
                 debug("parseJSON: %s\n", parsed.dump().c_str());
 
                 if (isEvent(parsed)) {
-                    CallbackHandler::push_event(new Event(
-                        *parsed.find("topic"), *parsed.find("payload")));
+                    CallbackHandler::push_event(
+                        new Event(*parsed.find("topic"), *parsed.find("group"),
+                                  *parsed.find("payload")));
                     WARDuino::instance()->debugger->notifyPushedEvent();
                 }
 

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -546,9 +546,7 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
 def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
 def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
 
 // MQTT MODULE

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -82,9 +82,9 @@ int isr_index = 0;
 #define INTERRUPT_TOPIC_PREFIX "interrupt_"
 
 /* Private macro to create an ISR for a specific pin*/
-#define def_isr(pin)                                               \
-    void isr_##pin() {                                             \
-        CallbackHandler::push_event(INTERRUPT_TOPIC_PREFIX #pin,   \
+#define def_isr(pin)                                                     \
+    void isr_##pin() {                                                   \
+        CallbackHandler::push_event(INTERRUPT_TOPIC_PREFIX #pin,         \
                                     EventGroup::INTERRUPT_EVENT, "", 0); \
     }
 

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -894,9 +894,7 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(unmask_interrupts);
 
     install_global(event_groups_all);
-    install_global(event_group_debugger);
     install_global(event_group_interrupt);
-    install_global(event_group_proxy);
     install_global(event_group_mqtt);
 
     dbg_info("INSTALLING ISRs\n");

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -82,9 +82,10 @@ int isr_index = 0;
 #define INTERRUPT_TOPIC_PREFIX "interrupt_"
 
 /* Private macro to create an ISR for a specific pin*/
-#define def_isr(pin)                                                     \
-    void isr_##pin() {                                                   \
-        CallbackHandler::push_event(INTERRUPT_TOPIC_PREFIX #pin, "", 0); \
+#define def_isr(pin)                                               \
+    void isr_##pin() {                                             \
+        CallbackHandler::push_event(INTERRUPT_TOPIC_PREFIX #pin,   \
+                                    EventGroup::INTERRUPT, "", 0); \
     }
 
 /* Common GPIO pins on ESP32 devices:*/
@@ -129,7 +130,7 @@ int resolve_isr(int pin) {
     return -1;
 }
 
-#define NUM_GLOBALS 0
+#define NUM_GLOBALS 5
 #define ALL_GLOBALS NUM_GLOBALS
 
 int global_index = 0;
@@ -523,6 +524,33 @@ def_prim(unsubscribe_interrupt, oneToNoneU32) {
     return true;
 }
 
+// Interrupt masking
+
+def_prim(mask_interrupts, twoToNoneU32) {
+    uint8_t discard = arg0.uint32;
+    uint8_t group = arg1.uint32;
+    debug("EMU: mask_interrupt(%u, %u) \n", discard, group);
+    pop_args(2);
+    uint32_t key = CallbackHandler::mask_interrupt(
+        static_cast<EventGroup>(group), discard);
+    pushUInt32(key);
+    return true;
+}
+
+def_prim(unmask_interrupts, oneToNoneU32) {
+    uint8_t key = arg0.uint32;
+    debug("EMU: unmask_interrupt(%u) \n", key);
+    pop_args(1);
+    CallbackHandler::unmask_interrupt(key);
+    return true;
+}
+
+def_glob(event_groups_all, I32, false, 0xffffffff);
+def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
+def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+
 // MQTT MODULE
 
 #include <PubSubClient.h>
@@ -541,7 +569,8 @@ def_prim(mqtt_init, threeToNoneU32) {
     mqttClient.setServer(server, port);
     mqttClient.setCallback([](const char *topic, const unsigned char *payload,
                               unsigned int length) {
-        CallbackHandler::push_event(topic, (const char *)payload, length);
+        CallbackHandler::push_event(topic, EventGroup::MQTT,
+                                    (const char *)payload, length);
     });
 
 #if DEBUG
@@ -862,6 +891,15 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(chip_analog_write);
     install_primitive(chip_ledc_attach);
     install_primitive(chip_ledc_set_duty);
+
+    install_primitive(mask_interrupts);
+    install_primitive(unmask_interrupts);
+
+    install_global(event_groups_all);
+    install_global(event_group_debugger);
+    install_global(event_group_interrupt);
+    install_global(event_group_proxy);
+    install_global(event_group_mqtt);
 
     dbg_info("INSTALLING ISRs\n");
     install_isrs();

--- a/src/Primitives/arduino.cpp
+++ b/src/Primitives/arduino.cpp
@@ -85,7 +85,7 @@ int isr_index = 0;
 #define def_isr(pin)                                               \
     void isr_##pin() {                                             \
         CallbackHandler::push_event(INTERRUPT_TOPIC_PREFIX #pin,   \
-                                    EventGroup::INTERRUPT, "", 0); \
+                                    EventGroup::INTERRUPT_EVENT, "", 0); \
     }
 
 /* Common GPIO pins on ESP32 devices:*/
@@ -546,8 +546,8 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT_EVENT);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT_EVENT);
 
 // MQTT MODULE
 
@@ -567,7 +567,7 @@ def_prim(mqtt_init, threeToNoneU32) {
     mqttClient.setServer(server, port);
     mqttClient.setCallback([](const char *topic, const unsigned char *payload,
                               unsigned int length) {
-        CallbackHandler::push_event(topic, EventGroup::MQTT,
+        CallbackHandler::push_event(topic, EventGroup::MQTT_EVENT,
                                     (const char *)payload, length);
     });
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -548,9 +548,7 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(test);
 
     install_global(event_groups_all);
-    install_global(event_group_debugger);
     install_global(event_group_interrupt);
-    install_global(event_group_proxy);
     install_global(event_group_mqtt);
 }
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -484,9 +484,7 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
 def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
 def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
 
 //------------------------------------------------------

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -26,7 +26,7 @@
 #include "../WARDuino/CallbackHandler.h"
 #include "primitives.h"
 
-#define NUM_GLOBALS 0
+#define NUM_GLOBALS 5
 #define ALL_GLOBALS NUM_GLOBALS
 
 int global_index = 0;
@@ -103,8 +103,8 @@ def_prim(test, oneToNoneU32) {
     Callback c = Callback(m, topic, fidx);
     CallbackHandler::add_callback(c);
     auto *payload = reinterpret_cast<const unsigned char *>("TestPayload");
-    CallbackHandler::push_event(topic, reinterpret_cast<const char *>(payload),
-                                11);
+    CallbackHandler::push_event(topic, EventGroup::INTERRUPT,
+                                reinterpret_cast<const char *>(payload), 11);
     pop_args(1);
     return true;
 }
@@ -462,6 +462,33 @@ def_prim(chip_ledc_attach_pin, twoToNoneU32) {
     return true;
 }
 
+// Interrupt masking
+
+def_prim(mask_interrupts, twoToNoneU32) {
+    uint8_t discard = arg0.uint32;
+    uint8_t group = arg1.uint32;
+    debug("EMU: mask_interrupt(%u, %u) \n", discard, group);
+    pop_args(2);
+    uint32_t key = CallbackHandler::mask_interrupt(
+        static_cast<EventGroup>(group), discard);
+    pushUInt32(key);
+    return true;
+}
+
+def_prim(unmask_interrupts, oneToNoneU32) {
+    uint8_t key = arg0.uint32;
+    debug("EMU: unmask_interrupt(%u) \n", key);
+    pop_args(1);
+    CallbackHandler::unmask_interrupt(key);
+    return true;
+}
+
+def_glob(event_groups_all, I32, false, 0xffffffff);
+def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
+def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+
 //------------------------------------------------------
 // Installing all the primitives
 //------------------------------------------------------
@@ -516,6 +543,17 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(read_uart_sensor);
     install_primitive(nxt_touch_sensor);
     install_primitive(ev3_touch_sensor);
+
+    // Interrupt masking & disabling
+    install_primitive(mask_interrupts);
+    install_primitive(unmask_interrupts);
+    install_primitive(test);
+
+    install_global(event_groups_all);
+    install_global(event_group_debugger);
+    install_global(event_group_interrupt);
+    install_global(event_group_proxy);
+    install_global(event_group_mqtt);
 }
 
 Memory external_mem{};

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -103,7 +103,7 @@ def_prim(test, oneToNoneU32) {
     Callback c = Callback(m, topic, fidx);
     CallbackHandler::add_callback(c);
     auto *payload = reinterpret_cast<const unsigned char *>("TestPayload");
-    CallbackHandler::push_event(topic, EventGroup::INTERRUPT,
+    CallbackHandler::push_event(topic, EventGroup::INTERRUPT_EVENT,
                                 reinterpret_cast<const char *>(payload), 11);
     pop_args(1);
     return true;
@@ -484,8 +484,8 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT_EVENT);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT_EVENT);
 
 //------------------------------------------------------
 // Installing all the primitives

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -24,7 +24,7 @@
 #include "../Memory/mem.h"
 #include "../Utils/macros.h"
 #include "../Utils/util.h"
-#include "../WARDuino/CallbackHandler.cpp"
+#include "../WARDuino/CallbackHandler.h"
 #include "driver/gpio.h"
 #include "primitives.h"
 
@@ -99,8 +99,8 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT_EVENT);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT_EVENT);
 
 //------------------------------------------------------
 // Installing all the primitives

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -27,7 +27,7 @@
 #include "driver/gpio.h"
 #include "primitives.h"
 
-#define NUM_GLOBALS 0
+#define NUM_GLOBALS 5
 #define ALL_GLOBALS NUM_GLOBALS
 
 int global_index = 0;
@@ -76,6 +76,33 @@ def_prim(chip_digital_read, oneToOneU32) {
     return true;
 }
 
+// Interrupt masking
+
+def_prim(mask_interrupts, twoToNoneU32) {
+    uint8_t discard = arg0.uint32;
+    uint8_t group = arg1.uint32;
+    debug("EMU: mask_interrupt(%u, %u) \n", discard, group);
+    pop_args(2);
+    uint32_t key = CallbackHandler::mask_interrupt(
+        static_cast<EventGroup>(group), discard);
+    pushUInt32(key);
+    return true;
+}
+
+def_prim(unmask_interrupts, oneToNoneU32) {
+    uint8_t key = arg0.uint32;
+    debug("EMU: unmask_interrupt(%u) \n", key);
+    pop_args(1);
+    CallbackHandler::unmask_interrupt(key);
+    return true;
+}
+
+def_glob(event_groups_all, I32, false, 0xffffffff);
+def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
+def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+
 //------------------------------------------------------
 // Installing all the primitives
 //------------------------------------------------------
@@ -85,6 +112,15 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(chip_pin_mode);
     install_primitive(chip_digital_write);
     install_primitive(chip_digital_read);
+
+    install_primitive(mask_interrupts);
+    install_primitive(unmask_interrupts);
+
+    install_global(event_groups_all);
+    install_global(event_group_debugger);
+    install_global(event_group_interrupt);
+    install_global(event_group_proxy);
+    install_global(event_group_mqtt);
 }
 
 Memory external_mem = {0, 0, 0, nullptr};

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -115,9 +115,7 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(unmask_interrupts);
 
     install_global(event_groups_all);
-    install_global(event_group_debugger);
     install_global(event_group_interrupt);
-    install_global(event_group_proxy);
     install_global(event_group_mqtt);
 }
 

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -24,6 +24,7 @@
 #include "../Memory/mem.h"
 #include "../Utils/macros.h"
 #include "../Utils/util.h"
+#include "../WARDuino/CallbackHandler.cpp"
 #include "driver/gpio.h"
 #include "primitives.h"
 

--- a/src/Primitives/idf.cpp
+++ b/src/Primitives/idf.cpp
@@ -98,9 +98,7 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
 def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
 def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
 
 //------------------------------------------------------

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -546,9 +546,7 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(unmask_interrupts);
 
     install_global(event_groups_all);
-    install_global(event_group_debugger);
     install_global(event_group_interrupt);
-    install_global(event_group_proxy);
     install_global(event_group_mqtt);
 
 #ifdef CONFIG_BOARD_STM32L496G_DISCO

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -31,11 +31,12 @@
 #include "../Memory/mem.h"
 #include "../Utils/macros.h"
 #include "../Utils/util.h"
+#include "../WARDuino/CallbackHandler.h"
 #include "Mindstorms/Motor.h"
 #include "Mindstorms/uart_sensor.h"
 #include "primitives.h"
 
-#define NUM_GLOBALS 0
+#define NUM_GLOBALS 5
 #define ALL_GLOBALS NUM_GLOBALS
 
 int global_index = 0;
@@ -501,6 +502,33 @@ def_prim(display_draw_string, sevenToNoneU32) {
 }
 #endif
 
+// Interrupt masking
+
+def_prim(mask_interrupts, twoToNoneU32) {
+    uint8_t discard = arg0.uint32;
+    uint8_t group = arg1.uint32;
+    debug("EMU: mask_interrupt(%u, %u) \n", discard, group);
+    pop_args(2);
+    uint32_t key = CallbackHandler::mask_interrupt(
+        static_cast<EventGroup>(group), discard);
+    pushUInt32(key);
+    return true;
+}
+
+def_prim(unmask_interrupts, oneToNoneU32) {
+    uint8_t key = arg0.uint32;
+    debug("EMU: unmask_interrupt(%u) \n", key);
+    pop_args(1);
+    CallbackHandler::unmask_interrupt(key);
+    return true;
+}
+
+def_glob(event_groups_all, I32, false, 0xffffffff);
+def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
+def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+
 //------------------------------------------------------
 // Installing all the primitives
 //------------------------------------------------------
@@ -515,6 +543,15 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(print_string);
     install_primitive(print_int);
     install_primitive(abort);
+
+    install_primitive(mask_interrupts);
+    install_primitive(unmask_interrupts);
+
+    install_global(event_groups_all);
+    install_global(event_group_debugger);
+    install_global(event_group_interrupt);
+    install_global(event_group_proxy);
+    install_global(event_group_mqtt);
 
 #ifdef CONFIG_BOARD_STM32L496G_DISCO
     install_primitive(drive_motor);

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -524,9 +524,7 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_debugger, I32, false, EventGroup::DEBUGGER);
 def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_proxy, I32, false, EventGroup::PROXY);
 def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
 
 //------------------------------------------------------

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -524,8 +524,8 @@ def_prim(unmask_interrupts, oneToNoneU32) {
 }
 
 def_glob(event_groups_all, I32, false, 0xffffffff);
-def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT);
-def_glob(event_group_mqtt, I32, false, EventGroup::MQTT);
+def_glob(event_group_interrupt, I32, false, EventGroup::INTERRUPT_EVENT);
+def_glob(event_group_mqtt, I32, false, EventGroup::MQTT_EVENT);
 
 //------------------------------------------------------
 // Installing all the primitives

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -67,12 +67,47 @@ size_t CallbackHandler::callback_count(const std::string &topic) {
     return callbacks->find(topic)->second->size();
 }
 
+// key counter starts at 1
+// reset every time the interrupt_mask_topic_to_keys is emptied
+uint32_t CallbackHandler::interrupt_mask_fresh_key = 1;
+
+std::unordered_map<EventGroup, std::unordered_set<uint32_t>>
+    *CallbackHandler::event_group_to_keys =
+        new std::unordered_map<EventGroup, std::unordered_set<uint32_t>>();
+
+uint32_t CallbackHandler::mask_interrupt(EventGroup group, bool discard) {
+    uint32_t key = CallbackHandler::interrupt_mask_fresh_key++;
+    (*event_group_to_keys)[group].insert(key);
+    debug("Masked interrupt with group %u using key %u (discard: %u)\n", group,
+          key, discard);
+    return key;
+}
+
+void CallbackHandler::unmask_interrupt(uint32_t key) {
+    for (auto &[group, keys] : *event_group_to_keys) {
+        if (keys.find(key) != keys.end()) {
+            keys.erase(key);
+            debug("Unmasked interrupt with key %u for group %u\n", key, group);
+            if (keys.empty()) {  // no more masked interrupts in this group
+                event_group_to_keys->erase(group);
+                debug("No more masked interrupts for group %u. Erased group.\n",
+                      group);
+            }
+            break;
+        }
+    }
+    if (event_group_to_keys->empty()) {
+        CallbackHandler::interrupt_mask_fresh_key = 1;  // reset key counter
+    }
+}
+
 // WARNING: Push event functions should not use IO functions, since they can be
 // called from ISR callbacks
-void CallbackHandler::push_event(std::string topic, const char *payload,
+void CallbackHandler::push_event(std::string topic, EventGroup group,
+                                 const char *payload,
                                  const unsigned int length) {
     CallbackHandler::push_event(
-        new Event(std::move(topic), std::string(payload, length)));
+        new Event(std::move(topic), group, std::string(payload, length)));
 }
 
 void CallbackHandler::push_event(Event *event) {
@@ -92,6 +127,18 @@ bool CallbackHandler::resolve_event(bool force) {
         return false;
     }
     Event event = CallbackHandler::events->front();
+    auto entry = event_group_to_keys->find(event.group);
+    auto keys = entry != event_group_to_keys->end() ? &entry->second : nullptr;
+    if (keys != nullptr &&
+        !keys->empty()) {  // second check is acutally redundant
+        debug("Event with topic %s and group %u is masked by keys: ",
+              event.topic.c_str(), event.group);
+        for (auto key : *keys) {
+            debug("%u ", key);
+        }
+        debug("\n");
+        return false;
+    }
 
     if (should_push_event()) {
         Event e = CallbackHandler::events->at(CallbackHandler::pushed_cursor++);
@@ -238,12 +285,14 @@ Callback::Callback(const Callback &c) {
 
 // Event class
 
-Event::Event(std::string topic, std::string payload) {
+Event::Event(std::string topic, EventGroup group, std::string payload) {
     this->topic = topic;
+    this->group = group;
     this->payload = payload;
 }
 
 std::string Event::serialized() const {
-    return R"({"topic": ")" + this->topic + R"(", "payload": ")" +
-           this->payload + R"("})";
+    return R"({"topic": ")" + this->topic + R"(", "group": ")" +
+           std::to_string(static_cast<uint8_t>(this->group)) +
+           R"(", "payload": ")" + this->payload + R"("})";
 }

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -71,29 +71,40 @@ size_t CallbackHandler::callback_count(const std::string &topic) {
 // reset every time the interrupt_mask_topic_to_keys is emptied
 uint32_t CallbackHandler::interrupt_mask_fresh_key = 1;
 
-std::unordered_map<EventGroup, std::unordered_set<uint32_t>>
+std::unordered_map<EventGroup, std::pair<std::unordered_set<uint32_t>,
+                                         std::unordered_set<uint32_t>>>
     *CallbackHandler::event_group_to_keys =
-        new std::unordered_map<EventGroup, std::unordered_set<uint32_t>>();
+        new std::unordered_map<EventGroup,
+                               std::pair<std::unordered_set<uint32_t>,
+                                         std::unordered_set<uint32_t>>>();
 
 uint32_t CallbackHandler::mask_interrupt(EventGroup group, bool discard) {
     uint32_t key = CallbackHandler::interrupt_mask_fresh_key++;
-    (*event_group_to_keys)[group].insert(key);
+    std::unordered_set<uint32_t> event_keys =
+        discard ? (*event_group_to_keys)[group].second
+                : (*event_group_to_keys)[group].first;
+    event_keys.insert(key);
     debug("Masked interrupt with group %u using key %u (discard: %u)\n", group,
           key, discard);
     return key;
 }
 
 void CallbackHandler::unmask_interrupt(uint32_t key) {
-    for (auto &[group, keys] : *event_group_to_keys) {
-        if (keys.find(key) != keys.end()) {
-            keys.erase(key);
-            debug("Unmasked interrupt with key %u for group %u\n", key, group);
-            if (keys.empty()) {  // no more masked interrupts in this group
-                event_group_to_keys->erase(group);
-                debug("No more masked interrupts for group %u. Erased group.\n",
+    for (auto &[group, pair] : *event_group_to_keys) {
+        for (std::unordered_set<uint32_t> *keys : {&pair.first, &pair.second}) {
+            if (keys->find(key) != keys->end()) {
+                keys->erase(key);
+                debug("Unmasked interrupt with key %u for group %u\n", key,
                       group);
+                if (keys->empty()) {  // no more masked interrupts in this group
+                    event_group_to_keys->erase(group);
+                    debug(
+                        "No more masked interrupts for group %u. Erased "
+                        "group.\n",
+                        group);
+                }
+                break;
             }
-            break;
         }
     }
     if (event_group_to_keys->empty()) {
@@ -111,6 +122,20 @@ void CallbackHandler::push_event(std::string topic, EventGroup group,
 }
 
 void CallbackHandler::push_event(Event *event) {
+    auto entry = CallbackHandler::event_group_to_keys->find(event->group);
+    auto keys = entry != CallbackHandler::event_group_to_keys->end()
+                    ? &entry->second.first
+                    : nullptr;
+    if (keys != nullptr &&
+        !keys->empty()) {  // first check is actually redundant
+        debug("Not pushing event with topic %s and group %u, because of keys: ",
+              event->topic.c_str(), event->group);
+        for (auto key : *keys) {
+            debug("%u ", key);
+        }
+        debug("\n");
+        return;
+    }
     if (events->size() < EVENTS_SIZE) {
         events->push_back(*event);
     }
@@ -128,7 +153,8 @@ bool CallbackHandler::resolve_event(bool force) {
     }
     Event event = CallbackHandler::events->front();
     auto entry = event_group_to_keys->find(event.group);
-    auto keys = entry != event_group_to_keys->end() ? &entry->second : nullptr;
+    auto keys =
+        entry != event_group_to_keys->end() ? &entry->second.second : nullptr;
     if (keys != nullptr &&
         !keys->empty()) {  // second check is acutally redundant
         debug("Event with topic %s and group %u is masked by keys: ",

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -90,25 +90,21 @@ uint32_t CallbackHandler::mask_interrupt(EventGroup group, bool discard) {
 }
 
 void CallbackHandler::unmask_interrupt(uint32_t key) {
+    std::vector<EventGroup> groups_to_remove;
+
     for (auto &[group, pair] : *event_group_to_keys) {
-        for (std::unordered_set<uint32_t> *keys : {&pair.first, &pair.second}) {
-            if (keys->find(key) != keys->end()) {
-                keys->erase(key);
-                debug("Unmasked interrupt with key %u for group %u\n", key,
-                      group);
-                if (keys->empty()) {  // no more masked interrupts in this group
-                    event_group_to_keys->erase(group);
-                    debug(
-                        "No more masked interrupts for group %u. Erased "
-                        "group.\n",
-                        group);
+        for (auto *keys : {&pair.first, &pair.second}) {
+            if (keys->erase(key)) {
+                if (pair.first.empty() && pair.second.empty()) {
+                    groups_to_remove.push_back(group);
                 }
                 break;
             }
         }
     }
-    if (event_group_to_keys->empty()) {
-        CallbackHandler::interrupt_mask_fresh_key = 1;  // reset key counter
+
+    for (auto g : groups_to_remove) {
+        event_group_to_keys->erase(g);
     }
 }
 
@@ -124,7 +120,7 @@ void CallbackHandler::push_event(std::string topic, EventGroup group,
 void CallbackHandler::push_event(Event *event) {
     auto entry = CallbackHandler::event_group_to_keys->find(event->group);
     auto keys = entry != CallbackHandler::event_group_to_keys->end()
-                    ? &entry->second.first
+                    ? &entry->second.second
                     : nullptr;
     if (keys != nullptr &&
         !keys->empty()) {  // first check is actually redundant
@@ -154,7 +150,7 @@ bool CallbackHandler::resolve_event(bool force) {
     Event event = CallbackHandler::events->front();
     auto entry = event_group_to_keys->find(event.group);
     auto keys =
-        entry != event_group_to_keys->end() ? &entry->second.second : nullptr;
+        entry != event_group_to_keys->end() ? &entry->second.first : nullptr;
     if (keys != nullptr &&
         !keys->empty()) {  // second check is acutally redundant
         debug("Event with topic %s and group %u is masked by keys: ",

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -124,12 +124,8 @@ void CallbackHandler::push_event(Event *event) {
                     : nullptr;
     if (keys != nullptr &&
         !keys->empty()) {  // first check is actually redundant
-        debug("Not pushing event with topic %s and group %u, because of keys: ",
+        debug("Not pushing event with topic %s and group %u\n",
               event->topic.c_str(), event->group);
-        for (auto key : *keys) {
-            debug("%u ", key);
-        }
-        debug("\n");
         return;
     }
     if (events->size() < EVENTS_SIZE) {
@@ -153,12 +149,8 @@ bool CallbackHandler::resolve_event(bool force) {
         entry != event_group_to_keys->end() ? &entry->second.first : nullptr;
     if (keys != nullptr &&
         !keys->empty()) {  // second check is acutally redundant
-        debug("Event with topic %s and group %u is masked by keys: ",
+        debug("Event with topic %s and group %u is masked.\n",
               event.topic.c_str(), event.group);
-        for (auto key : *keys) {
-            debug("%u ", key);
-        }
-        debug("\n");
         return false;
     }
 

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -147,7 +147,6 @@ void CallbackHandler::push_event(Event *event) {
     }
 
     // check if discarded for event group
-    auto &all_discard_keys = all_event_groups_keys->second;
     auto entry = CallbackHandler::event_group_to_keys->find(event->group);
     auto keys = entry != CallbackHandler::event_group_to_keys->end()
                     ? &entry->second.second

--- a/src/WARDuino/CallbackHandler.cpp
+++ b/src/WARDuino/CallbackHandler.cpp
@@ -71,6 +71,7 @@ size_t CallbackHandler::callback_count(const std::string &topic) {
 // reset every time the interrupt_mask_topic_to_keys is emptied
 uint32_t CallbackHandler::interrupt_mask_fresh_key = 1;
 
+// map of < event group , ( set of disable keys , set of discard keys ) >
 std::unordered_map<EventGroup, std::pair<std::unordered_set<uint32_t>,
                                          std::unordered_set<uint32_t>>>
     *CallbackHandler::event_group_to_keys =
@@ -78,19 +79,38 @@ std::unordered_map<EventGroup, std::pair<std::unordered_set<uint32_t>,
                                std::pair<std::unordered_set<uint32_t>,
                                          std::unordered_set<uint32_t>>>();
 
+// ( set of disable keys , set of discard keys ) that impact ALL events
+std::pair<std::unordered_set<uint32_t>, std::unordered_set<uint32_t>>
+    *CallbackHandler::all_event_groups_keys =
+        new std::pair<std::unordered_set<uint32_t>,
+                      std::unordered_set<uint32_t>>();
+
 uint32_t CallbackHandler::mask_interrupt(EventGroup group, bool discard) {
     uint32_t key = CallbackHandler::interrupt_mask_fresh_key++;
-    std::unordered_set<uint32_t> event_keys =
-        discard ? (*event_group_to_keys)[group].second
-                : (*event_group_to_keys)[group].first;
+    bool all_events = static_cast<uint8_t>(group) == 0xff;
+    auto &pair_of_keys =
+        all_events ? *all_event_groups_keys : (*event_group_to_keys)[group];
+    std::unordered_set<uint32_t> &event_keys =
+        discard ? pair_of_keys.second : pair_of_keys.first;
     event_keys.insert(key);
-    debug("Masked interrupt with group %u using key %u (discard: %u)\n", group,
-          key, discard);
+    printf("Masked interrupt with group %u using key %u (discard: %u)\n", group,
+           key, discard);
+    printf(
+        "All event groups keys now has %zu disable keys and %zu discard keys\n",
+        all_event_groups_keys->first.size(),
+        all_event_groups_keys->second.size());
     return key;
 }
 
 void CallbackHandler::unmask_interrupt(uint32_t key) {
     std::vector<EventGroup> groups_to_remove;
+
+    for (auto *keys :
+         {&all_event_groups_keys->first, &all_event_groups_keys->second}) {
+        if (keys->erase(key)) {
+            return;
+        }
+    }
 
     for (auto &[group, pair] : *event_group_to_keys) {
         for (auto *keys : {&pair.first, &pair.second}) {
@@ -118,16 +138,28 @@ void CallbackHandler::push_event(std::string topic, EventGroup group,
 }
 
 void CallbackHandler::push_event(Event *event) {
+    // check if discarded for all events
+    auto &disable_all_groups_keys = all_event_groups_keys->second;
+    if (disable_all_groups_keys.size()) {
+        printf("Not pushing event with topic %s and group %u\n",
+               event->topic.c_str(), event->group);
+        return;
+    }
+
+    // check if discarded for event group
+    auto &all_discard_keys = all_event_groups_keys->second;
     auto entry = CallbackHandler::event_group_to_keys->find(event->group);
     auto keys = entry != CallbackHandler::event_group_to_keys->end()
                     ? &entry->second.second
                     : nullptr;
     if (keys != nullptr &&
-        !keys->empty()) {  // first check is actually redundant
+        !keys->empty()) {  // second check is actually redundant
         debug("Not pushing event with topic %s and group %u\n",
               event->topic.c_str(), event->group);
         return;
     }
+
+    // push the event if not discarded
     if (events->size() < EVENTS_SIZE) {
         events->push_back(*event);
     }
@@ -143,6 +175,19 @@ bool CallbackHandler::resolve_event(bool force) {
         }
         return false;
     }
+
+    // check if masked for all events
+    auto &disable_all_groups_keys = all_event_groups_keys->first;
+    if (disable_all_groups_keys.size()) {
+        debug(
+            "Event with topic %s and group %u is masked for all event "
+            "groups.\n",
+            CallbackHandler::events->front().topic.c_str(),
+            CallbackHandler::events->front().group);
+        return false;
+    }
+
+    // check if masked for event group
     Event event = CallbackHandler::events->front();
     auto entry = event_group_to_keys->find(event.group);
     auto keys =

--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -4,18 +4,27 @@
 #include <queue>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 struct Module;
 
 class Callback;
 
+enum EventGroup : uint8_t {
+    DEBUGGER = 0,
+    INTERRUPT = 1,
+    PROXY = 2,
+    MQTT = 3,
+};
+
 class Event {
    public:
     std::string topic;
+    EventGroup group;
     std::string payload;
 
-    Event(std::string topic, std::string payload);
+    Event(std::string topic, EventGroup group, std::string payload);
 
     std::string serialized() const;
 };
@@ -23,6 +32,9 @@ class Event {
 class CallbackHandler {
    private:
     static std::unordered_map<std::string, std::vector<Callback> *> *callbacks;
+    static uint32_t interrupt_mask_fresh_key;
+    static std::unordered_map<EventGroup, std::unordered_set<uint32_t>>
+        *event_group_to_keys;
     static std::deque<Event> *events;
 
     CallbackHandler() = default;  // Disallow creation
@@ -42,12 +54,15 @@ class CallbackHandler {
     static std::string dump_callbacks();
     static std::string dump_callbacksV2(bool includeOuterCurlyBraces = true);
     static size_t callback_count(const std::string &topic);
-    static void push_event(std::string topic, const char *payload,
-                           unsigned int length);
+    static void push_event(std::string topic, EventGroup group,
+                           const char *payload, unsigned int length);
     static void push_event(Event *event);
     static bool resolve_event(bool force = false);
 
     static bool manual_event_resolution;  // do not resolve event automatically
+
+    static uint32_t mask_interrupt(EventGroup group, bool discard);
+    static void unmask_interrupt(uint32_t key);
 };
 
 class Callback {

--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -33,7 +33,9 @@ class CallbackHandler {
    private:
     static std::unordered_map<std::string, std::vector<Callback> *> *callbacks;
     static uint32_t interrupt_mask_fresh_key;
-    static std::unordered_map<EventGroup, std::unordered_set<uint32_t>>
+    static std::unordered_map<
+        EventGroup,
+        std::pair<std::unordered_set<uint32_t>, std::unordered_set<uint32_t>>>
         *event_group_to_keys;
     static std::deque<Event> *events;
 

--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -12,8 +12,9 @@ struct Module;
 class Callback;
 
 enum EventGroup : uint8_t {
-    INTERRUPT = 0,
-    MQTT = 1,
+    // do not rename to INTERRUPT (ESP32 headers define an INTERRUPT macro)
+    INTERRUPT_EVENT = 0,
+    MQTT_EVENT = 1,
 };
 
 class Event {

--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -12,10 +12,8 @@ struct Module;
 class Callback;
 
 enum EventGroup : uint8_t {
-    DEBUGGER = 0,
-    INTERRUPT = 1,
-    PROXY = 2,
-    MQTT = 3,
+    INTERRUPT = 0,
+    MQTT = 1,
 };
 
 class Event {

--- a/src/WARDuino/CallbackHandler.h
+++ b/src/WARDuino/CallbackHandler.h
@@ -15,6 +15,8 @@ enum EventGroup : uint8_t {
     // do not rename to INTERRUPT (ESP32 headers define an INTERRUPT macro)
     INTERRUPT_EVENT = 0,
     MQTT_EVENT = 1,
+
+    // 0xff is reserved (to denote all eventgroups), do not use
 };
 
 class Event {
@@ -36,6 +38,8 @@ class CallbackHandler {
         EventGroup,
         std::pair<std::unordered_set<uint32_t>, std::unordered_set<uint32_t>>>
         *event_group_to_keys;
+    static std::pair<std::unordered_set<uint32_t>, std::unordered_set<uint32_t>>
+        *all_event_groups_keys;
     static std::deque<Event> *events;
 
     CallbackHandler() = default;  // Disallow creation

--- a/tutorials/wat/main/interrupt_masking.wast
+++ b/tutorials/wat/main/interrupt_masking.wast
@@ -1,0 +1,33 @@
+(module
+  (import "env" "mask_interrupts" (func $mask_interrupts (param i32 i32) (result i32)))
+  (import "env" "unmask_interrupts" (func $unmask_interrupts (param i32) ))
+  (import "env" "event_group_interrupt" (global $event_group_interrupt i32))
+  
+  (import "env" "test" (func $test (param i32)))
+  
+  (import "env" "print_int" (func $print.int (param i32)))
+
+  (func $main (export "main")
+    (local $key i32)
+    (local $i i32)
+    ;; mask interrupt with discarding and all event groups
+    ;; NOTE/TODO: currently, temporarily disabling the interrupts returns in an error when resolving the event pushed by the test interrupt
+    (local.set $key (call $mask_interrupts (global.get $event_group_interrupt) (i32.const 1)))
+
+    ;; 20 loops: in each iteration the interrupt is triggered, but discarded because of the discarding mask
+    (local.set $i (i32.const 0))
+    (loop $loop
+      (call $print.int (local.get $i))
+      (call $test (i32.const <<<<<<TODO_PROVIDE_FIDX>>>>>>)) ;; trigger the interrupt 
+      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+      (br_if $loop (i32.lt_s (local.get $i) (i32.const 20)))
+    )
+
+    ;; unmaks the interrupt using the returned key
+    (call $unmask_interrupts (local.get $key))
+  )
+
+  (func $test_callback (export "test_callback") (param $payload i32)
+    (call $print.int (i32.const 424242))
+  )
+)

--- a/tutorials/wat/main/interrupt_masking.wast
+++ b/tutorials/wat/main/interrupt_masking.wast
@@ -10,8 +10,7 @@
   (func $main (export "main")
     (local $key i32)
     (local $i i32)
-    ;; mask interrupt with discarding and all event groups
-    ;; NOTE/TODO: currently, temporarily disabling the interrupts returns in an error when resolving the event pushed by the test interrupt
+    ;; mask interrupt with discarding and only the events grouped as interrupt
     (local.set $key (call $mask_interrupts (global.get $event_group_interrupt) (i32.const 1)))
 
     ;; 20 loops: in each iteration the interrupt is triggered, but discarded because of the discarding mask


### PR DESCRIPTION
This PR introduces interrupt masking primitives.
Concretely, the functions `mask_interrupts` and `unmask_interrupts` are exposed as primitives to the source program.
These allow the developer to temporarily disable or discard events during critical sections of the code.

Two types of masking behaviour exist:
- discard mode (pass 1 to `mask_interrupts`): prevent events from being queued
- temporarily disable mode (pass 0 to `mask_interrupts`): allow events to enqueue, but block resolution until unmaksed 

Masks are identified and distinguished by their key, returned by the `mask_interrupts` function. This key must be used to later call `unmask_interrupts`. This allows for multiple (nested) masks to exist at the same time.

Events are now grouped by `EventGroup`s (`INTERRUPT_EVENT`, `MQTT_EVENT`). These groups are also exposed as `i32` primitive globals (`event_group_interrupt` or `event_group_mqtt`, and additionally `event_groups_all`), so they can be used in the `mask_interrupts` call to selectively disable one or all groups of events.

An example can be found in [tutorials/wat/main/interrupt_masking.wast](https://github.com/abelstuker/WARDuino/blob/de30e2e8454ea284be8e72839159bc558603a52d/tutorials/wat/main/interrupt_masking.wast).