### PR TITLE
Support display primitives on the Raspberry Pi Pico

### DIFF
--- a/platforms/Zephyr/boards/rpi_pico.overlay
+++ b/platforms/Zephyr/boards/rpi_pico.overlay
@@ -1,3 +1,5 @@
+#include <zephyr/dt-bindings/display/panel.h>
+
 #include "../app.overlay"
 
 / {
@@ -46,7 +48,7 @@
             <&gpio0 28 0>,
             <&gpio0 29 0>;
      };
-}; 
+};
 
 / {
     chosen {
@@ -66,9 +68,10 @@
             mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
             width = <240>;
             height = <320>;
-            pixel-format = <0>;
+            pixel-format = <PANEL_PIXEL_FORMAT_RGB_565>;
             rotation = <0>;
             status = "okay";
+            h-mirror;
         };
     };
 };

--- a/platforms/Zephyr/boards/rpi_pico.overlay
+++ b/platforms/Zephyr/boards/rpi_pico.overlay
@@ -47,3 +47,28 @@
             <&gpio0 29 0>;
      };
 }; 
+
+/ {
+    chosen {
+        zephyr,display = &ili9341;
+    };
+    mipi_dbi {
+        compatible = "zephyr,mipi-dbi-spi";
+        spi-dev = <&spi0>;
+        dc-gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
+        reset-gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+        ili9341: ili9341@0 {
+            compatible = "ilitek,ili9341";
+            reg = <0>;
+            mipi-max-frequency = <20000000>;
+            mipi-mode = "MIPI_DBI_MODE_SPI_4WIRE";
+            width = <240>;
+            height = <320>;
+            pixel-format = <0>;
+            rotation = <0>;
+            status = "okay";
+        };
+    };
+};

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -93,6 +93,11 @@ def_prim(micros, NoneToOneU64) {
     return true;
 }
 
+def_prim(random_int, NoneToOneU32) {
+    pushInt32(rand());
+    return true;
+}
+
 // call callback test function (temporary)
 def_prim(test, oneToNoneU32) {
     uint32_t fidx = arg0.uint32;
@@ -515,6 +520,7 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(abort);
     install_primitive(millis);
     install_primitive(micros);
+    install_primitive(random_int);
 
     install_primitive(print_int);
     install_primitive(print_string);

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -412,6 +412,44 @@ def_prim(ev3_touch_sensor, oneToOneU32) {
     return true;
 }
 
+def_prim(display_setup, NoneToNoneU32) {
+    printf("EMU: display_setup()\n");
+    return true;
+}
+
+def_prim(display_set_orientation, oneToNoneI32) {
+    printf("EMU: display_set_orientation(%d)\n", arg0.uint32);
+    pop_args(1);
+    return true;
+}
+
+def_prim(display_width, NoneToOneU32) {
+    printf("EMU: display_width()\n");
+    pushUInt32(320);
+    return true;
+}
+
+def_prim(display_height, NoneToOneU32) {
+    printf("EMU: display_height()\n");
+    pushUInt32(240);
+    return true;
+}
+
+def_prim(display_fill_rect, fiveToNoneU32) {
+    printf("EMU: display_fill_rect(%d, %d, %d, %d, %d)\n", arg4.int32,
+           arg3.int32, arg2.int32, arg1.int32, arg0.uint32);
+    pop_args(5);
+    return true;
+}
+
+def_prim(display_draw_string, sevenToNoneU32) {
+    printf("EMU: display_draw_string(%d %d %d, %d, %d, %d, %d)\n", arg6.int32,
+           arg5.int32, arg4.int32, arg3.int32, arg2.int32, arg1.int32,
+           arg0.uint32);
+    pop_args(7);
+    return true;
+}
+
 def_prim(subscribe_interrupt, threeToNoneU32) {
     uint8_t pin = arg2.uint32;   // GPIOPin
     uint8_t tidx = arg1.uint32;  // Table Idx pointing to Callback function
@@ -522,6 +560,14 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(read_uart_sensor);
     install_primitive(nxt_touch_sensor);
     install_primitive(ev3_touch_sensor);
+
+    // Display primitives
+    install_primitive(display_setup);
+    install_primitive(display_set_orientation);
+    install_primitive(display_width);
+    install_primitive(display_height);
+    install_primitive(display_fill_rect);
+    install_primitive(display_draw_string);
 
     install_primitive(heap_used);
 }

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -439,7 +439,7 @@ def_prim(display_setup, NoneToNoneU32) {
     struct display_capabilities capabilities;
 
     if (!device_is_ready(display_dev)) {
-        printf("Device %s not found. Aborting sample.", display_dev->name);
+        printf("Device %s is not ready.", display_dev->name);
         return false;
     }
 


### PR DESCRIPTION
Displays can now be connected on spi0 and use the existing display primitives to draw rectangles and text.

This PR only adds device tree data so that Zephyr knows where to find the display when running on a Raspberry Pi Pico.

Also adds dummy primitives to the emulator for the display primitives added in a previous PR.