### PR TITLE
Don't use uart_irq_rx_ready return type since it is now void instead of int

### DIFF
--- a/src/Primitives/Mindstorms/uart_sensor.cpp
+++ b/src/Primitives/Mindstorms/uart_sensor.cpp
@@ -9,9 +9,7 @@ void serial_cb(const struct device *dev, void *user_data) {
     auto *sensor = static_cast<UartSensor *>(user_data);
     uint8_t data;
 
-    if (!uart_irq_update(dev)) {
-        return;
-    }
+    uart_irq_update(dev);
 
     if (!uart_irq_rx_ready(dev)) {
         return;


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/105231