### PR TITLE
Initial piezo tone/noTone primitive support for zephyr

### DIFF
--- a/platforms/Zephyr/boards/rpi_pico.overlay
+++ b/platforms/Zephyr/boards/rpi_pico.overlay
@@ -49,6 +49,7 @@
             <&gpio0 29 0>;
 
         pwms = < &pwm 2 PWM_USEC(1500) PWM_POLARITY_NORMAL >;
+        pwm-names = "builtin-buzzer";
      };
 };
 

--- a/platforms/Zephyr/boards/rpi_pico.overlay
+++ b/platforms/Zephyr/boards/rpi_pico.overlay
@@ -47,6 +47,8 @@
             <&gpio0 27 0>,
             <&gpio0 28 0>,
             <&gpio0 29 0>;
+
+        pwms = < &pwm 2 PWM_USEC(1500) PWM_POLARITY_NORMAL >;
      };
 };
 
@@ -74,4 +76,18 @@
             h-mirror;
         };
     };
+};
+
+&pinctrl {
+    pwm_ch1a_default: pwm_ch1a_default {
+        group1 {
+            pinmux = <PWM_1A_P2>; // Channel 1 A, 1 * 1 + 1 = 2, &pwm 2 in pwms
+        };
+    };
+};
+
+&pwm {
+    status="okay";
+    divider-int-4 = <255>;
+    pinctrl-0 = < &pwm_ch1a_default >;
 };

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -130,8 +130,10 @@ def_prim(millis, NoneToOneU32) {
     return true;
 }
 
+#if DT_PROP_HAS_NAME(DT_PATH(zephyr_user), pwms, builtin_buzzer)
+
 static const struct pwm_dt_spec piezo_spec =
-    PWM_DT_SPEC_GET(DT_PATH(zephyr_user));
+    PWM_DT_SPEC_GET_BY_NAME(DT_PATH(zephyr_user), builtin_buzzer);
 
 bool pwm_write_freq(pwm_dt_spec pwm_spec, uint32_t period_us) {
     if (!pwm_is_ready_dt(&pwm_spec)) {
@@ -166,6 +168,8 @@ def_prim(noTone, NoneToNoneU32) {
     pwm_set_pulse_dt(&piezo_spec, 0);
     return true;
 }
+
+#endif
 
 def_prim(random_int, NoneToOneU32) {
     pushInt32(sys_rand32_get());
@@ -579,8 +583,10 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(display_draw_string);
 #endif
 
+#if DT_PROP_HAS_NAME(DT_PATH(zephyr_user), pwms, builtin_buzzer)
     install_primitive(tone);
     install_primitive(noTone);
+#endif
 }
 
 Memory external_mem = {0, 0, 0, nullptr};

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -130,6 +130,43 @@ def_prim(millis, NoneToOneU32) {
     return true;
 }
 
+static const struct pwm_dt_spec piezo_spec =
+    PWM_DT_SPEC_GET(DT_PATH(zephyr_user));
+
+bool pwm_write_freq(pwm_dt_spec pwm_spec, uint32_t period_us) {
+    if (!pwm_is_ready_dt(&pwm_spec)) {
+        printf("Error: PWM device %s is not ready\n", pwm_spec.dev->name);
+        return false;
+    }
+
+    uint32_t period = PWM_USEC(period_us);
+    int ret = pwm_set_dt(&pwm_spec, period, period / 2U);
+    if (ret) {
+        printf("Error %d: failed to set pulse width, period_us = %d\n", ret,
+               period_us);
+        return false;
+    }
+
+    return true;
+}
+
+def_prim(tone, oneToNoneI32) {
+    // The argument is in Hz, we convert it to a period in us.
+    pwm_write_freq(piezo_spec, 1000000 / arg0.uint32);
+    pop_args(1);
+    return true;
+}
+
+def_prim(noTone, NoneToNoneU32) {
+    if (!pwm_is_ready_dt(&piezo_spec)) {
+        printf("Error: PWM device %s is not ready\n", piezo_spec.dev->name);
+        return false;
+    }
+
+    pwm_set_pulse_dt(&piezo_spec, 0);
+    return true;
+}
+
 def_prim(random_int, NoneToOneU32) {
     pushInt32(sys_rand32_get());
     return true;
@@ -541,6 +578,9 @@ void install_primitives(Interpreter *interpreter) {
     install_primitive(display_fill_rect);
     install_primitive(display_draw_string);
 #endif
+
+    install_primitive(tone);
+    install_primitive(noTone);
 }
 
 Memory external_mem = {0, 0, 0, nullptr};


### PR DESCRIPTION
Adds primitives to control piezoelectric buzzers.

- `tone(freq)` start playing a tone at frequency freq Hz
- `noTone()` stop playing the sound

Currently these use a new overlay element that can be defined for boards called `builtin-buzzer`. We currently only define this for the Raspberry Pico as GPIO2. In the future we should allow arbitrary analog pins to be used.