### PR TITLE
Fix many memory leaks

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -196,7 +196,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             this->channel->write("STOP!\n");
             this->channel->close();
             free(interruptData);
-            m->warduino->free_module_state(m);
+            delete m->warduino;
             exit(0);
         case interruptPAUSE:
             this->pauseRuntime(m);
@@ -1034,6 +1034,7 @@ void Debugger::setSnapshotPolicy(Module *m, uint8_t *interruptData) {
         checkpointInterval = read_B32(&ptr);
         checkpoint(m, true);
     }
+    printf("ack%x\n", interruptSetSnapshotPolicy);
 }
 
 std::optional<uint32_t> getPrimitiveBeingCalled(Module *m, uint8_t *pc_ptr) {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -196,6 +196,7 @@ bool Debugger::checkDebugMessages(Module *m, RunningState *program_state) {
             this->channel->write("STOP!\n");
             this->channel->close();
             free(interruptData);
+            m->warduino->free_module_state(m);
             exit(0);
         case interruptPAUSE:
             this->pauseRuntime(m);
@@ -1651,11 +1652,8 @@ bool Debugger::handleUpdateStackValue(const Module *m, uint8_t *bytes) const {
 }
 
 bool Debugger::reset(Module *m) {
-    auto *wasm =
-        static_cast<uint8_t *>(malloc(sizeof(uint8_t) * m->byte_count));
-    memcpy(wasm, m->bytes, m->byte_count);
+    m->warduino->reset_module(m);
     instructions_executed = 0;
-    m->warduino->update_module(m, wasm, m->byte_count);
     this->channel->write("Reset WARDuino.\n");
     return true;
 }

--- a/src/WARDuino.h
+++ b/src/WARDuino.h
@@ -73,6 +73,8 @@ class WARDuino {
 
     void unload_module(Module *m);
 
+    void reset_module(Module *m);
+
     void update_module(Module *old_module, uint8_t *wasm, uint32_t wasm_len);
 
     std::vector<StackValue> invoke(Module *m, uint32_t fidx, uint32_t arity = 0,

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -371,6 +371,7 @@ void WARDuino::instantiate_module(Module *m, uint8_t *bytes,
                 } else {
                     dbg_warn("Ignoring unknown custom section '%s'\n", name);
                 }
+                free(name);
                 pos = end_pos;
                 break;
             }
@@ -653,6 +654,7 @@ void WARDuino::instantiate_module(Module *m, uint8_t *bytes,
                 if (m->import_count != 0) {
                     memcpy(functions, m->functions,
                            sizeof(Block) * m->import_count);
+                    free(m->functions);
                 }
                 m->functions = functions;
 
@@ -743,6 +745,7 @@ void WARDuino::instantiate_module(Module *m, uint8_t *bytes,
                                 "  ignoring non-function export '%s'"
                                 " kind 0x%x index 0x%x\n",
                                 name, kind, index);
+                            free(name);
                     }
                 }
                 break;
@@ -1160,14 +1163,24 @@ void WARDuino::free_module_state(Module *m) {
     }
 
     if (m->functions != nullptr) {
-        for (uint32_t i = 0; i < m->function_count; ++i)
+        for (uint32_t i = 0; i < m->function_count; ++i) {
             if (m->functions[i].export_name != nullptr)
                 free(m->functions[i].export_name);
+            if (m->functions[i].local_count)
+                free(m->functions[i].local_value_type);
+            if (m->functions[i].import_module)
+                free(m->functions[i].import_module);
+            if (m->functions[i].import_field)
+                free(m->functions[i].import_field);
+        }
         free(m->functions);
         m->functions = nullptr;
     }
 
     if (m->globals != nullptr) {
+        for (uint32_t i = 0; i < m->global_count; ++i)
+            if (m->globals[i]->export_name != nullptr)
+                free(m->globals[i]->export_name);
         free(m->globals);
         m->globals = nullptr;
     }
@@ -1204,6 +1217,9 @@ void WARDuino::free_module_state(Module *m) {
         free(m->exception);  // safe to remove?
     }
 
+    for (std::pair<uint8_t *, Block *> block : m->block_lookup) {
+        free(block.second);
+    }
     m->block_lookup.clear();
 }
 

--- a/src/WARDuino/WARDuino.cpp
+++ b/src/WARDuino/WARDuino.cpp
@@ -1223,6 +1223,28 @@ void WARDuino::free_module_state(Module *m) {
     m->block_lookup.clear();
 }
 
+void WARDuino::reset_module(Module *m) {
+    const uint32_t byte_count = m->byte_count;
+    free_module_state(m);  // Does not reset m->bytes
+    program_state = WARDUINOinit;
+    ExecutionContext *ectx = execution_context;
+    ectx->sp = -1;
+    ectx->fp = -1;
+    ectx->csp = -1;
+    ectx->current_module = m;
+    instantiate_module(m, m->bytes, byte_count);
+
+    uint32_t fidx = get_main_fidx(m);
+    // execute main
+    if (fidx != UNDEF) {
+        interpreter->setup_call(m, fidx);
+        program_state = WARDUINOrun;
+    }
+
+    // wait
+    debugger->pauseRuntime(m);
+}
+
 void WARDuino::update_module(Module *m, uint8_t *wasm, uint32_t wasm_len) {
     m->warduino->program_state = WARDUINOinit;
 


### PR DESCRIPTION
This PR fixes some (but not all) memory leaks in WARDuino. The main goal is to make the reset operation not leak a huge amount of memory so that it can actually be used on larger wasm programs on a microcontroller without crashing because it's running out of memory.

- [x] Fix init/free module state not freeing everything it allocates
- [x] Update reset in the debugger so it does not duplicate the module data (I have a basic version locally but it needs some more polish)