### PR TITLE
Return more primitive information with `--dump-info`

### DIFF
--- a/platforms/CLI-Emulator/main.cpp
+++ b/platforms/CLI-Emulator/main.cpp
@@ -276,6 +276,21 @@ StackValue parseParameter(const char *input, uint8_t value_type) {
     return value;
 }
 
+const char *valueTypeToString(uint8_t value_type) {
+    switch (value_type) {
+        case I32:
+            return "i32";
+        case I64:
+            return "i64";
+        case F32:
+            return "f32";
+        case F64:
+            return "f64";
+        default:
+            return "unknown";
+    }
+}
+
 int main(int argc, const char *argv[]) {
     ARGV_SHIFT();  // Skip command name
 
@@ -457,11 +472,36 @@ int main(int argc, const char *argv[]) {
             json["primitive_calls"] = primitive_calls;
             json["after_primitive_calls"] = after_primitive_calls;
 
-            std::vector<std::string> fidx_mapping = std::vector<std::string>();
+            auto primitives = nlohmann::json::array();
             for (uint32_t fidx = 0; fidx < m->import_count; fidx++) {
-                fidx_mapping.emplace_back(m->functions[fidx].import_field);
+                Block &primitive = m->functions[fidx];
+                auto primitive_json = nlohmann::json();
+                primitive_json["fidx"] = fidx;
+                primitive_json["name"] = primitive.import_field;
+                primitive_json["module"] = primitive.import_module;
+
+                auto arg_types = nlohmann::json::array();
+                if (primitive.type) {
+                    for (uint32_t i = 0; i < primitive.type->param_count; i++) {
+                        arg_types.push_back(valueTypeToString(
+                            static_cast<uint8_t>(primitive.type->params[i])));
+                    }
+                }
+                primitive_json["arg_types"] = arg_types;
+
+                auto return_types = nlohmann::json::array();
+                if (primitive.type) {
+                    for (uint32_t i = 0; i < primitive.type->result_count;
+                         i++) {
+                        return_types.push_back(valueTypeToString(
+                            static_cast<uint8_t>(primitive.type->results[i])));
+                    }
+                }
+                primitive_json["return_types"] = return_types;
+
+                primitives.push_back(primitive_json);
             }
-            json["primitive_fidx_mapping"] = fidx_mapping;
+            json["primitives"] = primitives;
 
             std::cout << json << std::endl;
             for (auto mod : loaded_modules) wac->unload_module(mod);


### PR DESCRIPTION
This PR makes it so that `--dump-info` now provides information about primitives such as the argument types, return types, name, module name, etc... This is great of debuggers such as MIO which can use this information for mocking and to map functions indexes to names. Previously only the names were available so the main things this adds is the counts and types of arguments and return values.

Example output (pretty printed with `jq`):
```json
"primitives": [
    {
      "arg_types": [
        "i32",
        "i32",
        "i32",
        "i32",
        "i32",
        "i32",
        "i32"
      ],
      "fidx": 0,
      "module": "env",
      "name": "display_draw_string",
      "return_types": []
    },
    {
      "arg_types": [
        "i32"
      ],
      "fidx": 1,
      "module": "env",
      "name": "chip_delay",
      "return_types": []
    },
    {
      "arg_types": [],
      "fidx": 2,
      "module": "env",
      "name": "display_setup",
      "return_types": []
    },
    {
      "arg_types": [
        "i32"
      ],
      "fidx": 3,
      "module": "env",
      "name": "display_set_orientation",
      "return_types": []
    },
    {
      "arg_types": [
        "i32",
        "i32",
        "i32",
        "i32",
        "i32"
      ],
      "fidx": 4,
      "module": "env",
      "name": "display_fill_rect",
      "return_types": []
    },
    {
      "arg_types": [
        "i32",
        "i32"
      ],
      "fidx": 5,
      "module": "env",
      "name": "chip_pin_mode",
      "return_types": []
    },
    {
      "arg_types": [
        "i32",
        "i32"
      ],
      "fidx": 6,
      "module": "env",
      "name": "chip_digital_write",
      "return_types": []
    },
    {
      "arg_types": [],
      "fidx": 7,
      "module": "env",
      "name": "display_height",
      "return_types": [
        "i32"
      ]
    },
    {
      "arg_types": [],
      "fidx": 8,
      "module": "env",
      "name": "display_width",
      "return_types": [
        "i32"
      ]
    },
    {
      "arg_types": [],
      "fidx": 9,
      "module": "env",
      "name": "random_int",
      "return_types": [
        "i32"
      ]
    }
  ]

```