### PR TITLE
Fix sockets using strlen to determine the length of the data sent

### DIFF
--- a/src/Primitives/Networking/sockets.h
+++ b/src/Primitives/Networking/sockets.h
@@ -65,10 +65,11 @@ inline int socket_accept(const int socket) {
     return client_sock;
 }
 
-inline int socket_send(const int socket, const char *message) {
-    printf("socket_send(%d, \"%s\" (len = %lu))\n", socket, message,
-           strlen(message));
-    return send(socket, message, strlen(message), 0);
+inline int socket_send(const int socket, const char *message,
+                       const size_t len) {
+    printf("socket_send(%d, \"%s\" (len = %d))\n", socket, message,
+           len);
+    return send(socket, message, len, 0);
 }
 
 inline int socket_receive(const int socket, char *buffer, const size_t size) {

--- a/src/Primitives/Networking/sockets.h
+++ b/src/Primitives/Networking/sockets.h
@@ -73,7 +73,7 @@ inline int socket_send(const int socket, const char *message,
 }
 
 inline int socket_receive(const int socket, char *buffer, const size_t size) {
-    printf("socket_receive(%d, 0x%p, %lu)\n", socket, buffer, size);
+    printf("socket_receive(%d, %p, %lu)\n", socket, buffer, size);
     return recv(socket, buffer, size, 0);
 }
 

--- a/src/Primitives/Networking/sockets.h
+++ b/src/Primitives/Networking/sockets.h
@@ -67,12 +67,12 @@ inline int socket_accept(const int socket) {
 
 inline int socket_send(const int socket, const char *message,
                        const size_t len) {
-    printf("socket_send(%d, \"%s\" (len = %d))\n", socket, message, len);
+    printf("socket_send(%d, \"%s\" (len = %zu))\n", socket, message, len);
     return send(socket, message, len, 0);
 }
 
 inline int socket_receive(const int socket, char *buffer, const size_t size) {
-    printf("socket_receive(%d, %p, %lu)\n", socket, buffer, size);
+    printf("socket_receive(%d, %p, %zu)\n", socket, buffer, size);
     return recv(socket, buffer, size, 0);
 }
 

--- a/src/Primitives/Networking/sockets.h
+++ b/src/Primitives/Networking/sockets.h
@@ -67,8 +67,7 @@ inline int socket_accept(const int socket) {
 
 inline int socket_send(const int socket, const char *message,
                        const size_t len) {
-    printf("socket_send(%d, \"%s\" (len = %d))\n", socket, message,
-           len);
+    printf("socket_send(%d, \"%s\" (len = %d))\n", socket, message, len);
     return send(socket, message, len, 0);
 }
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -212,13 +212,12 @@ def_prim(socket_accept, oneToOneI32) {
 }
 
 def_prim(socket_send, threeToOneU32) {
-    int32_t socket = arg2.int32;
-    uint32_t msg_addr = arg1.uint32;
-    uint32_t msg_len = arg0.uint32;
-    std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
+    const int32_t socket = arg2.int32;
+    const uint32_t msg_addr = arg1.uint32;
+    const uint32_t msg_len = arg0.uint32;
+    const std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
     pop_args(3);
-    int sent = sockets::socket_send(socket, msg.c_str());
-    pushInt32(sent);
+    pushInt32(sockets::socket_send(socket, msg.c_str(), msg_len));
     return true;
 }
 

--- a/src/Primitives/emulated.cpp
+++ b/src/Primitives/emulated.cpp
@@ -215,7 +215,8 @@ def_prim(socket_send, threeToOneU32) {
     const int32_t socket = arg2.int32;
     const uint32_t msg_addr = arg1.uint32;
     const uint32_t msg_len = arg0.uint32;
-    const std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
+    const std::string msg =
+        parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
     pop_args(3);
     pushInt32(sockets::socket_send(socket, msg.c_str(), msg_len));
     return true;

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -613,13 +613,12 @@ def_prim(socket_accept, oneToOneI32) {
 }
 
 def_prim(socket_send, threeToOneU32) {
-    int32_t socket = arg2.int32;
-    uint32_t msg_addr = arg1.uint32;
-    uint32_t msg_len = arg0.uint32;
-    std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
+    const int32_t socket = arg2.int32;
+    const uint32_t msg_addr = arg1.uint32;
+    const uint32_t msg_len = arg0.uint32;
+    const std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
     pop_args(3);
-    int sent = sockets::socket_send(socket, msg.c_str());
-    pushInt32(sent);
+    pushInt32(sockets::socket_send(socket, msg.c_str(), msg_len));
     return true;
 }
 

--- a/src/Primitives/zephyr.cpp
+++ b/src/Primitives/zephyr.cpp
@@ -616,7 +616,8 @@ def_prim(socket_send, threeToOneU32) {
     const int32_t socket = arg2.int32;
     const uint32_t msg_addr = arg1.uint32;
     const uint32_t msg_len = arg0.uint32;
-    const std::string msg = parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
+    const std::string msg =
+        parse_utf8_string(m->memory.bytes, msg_len, msg_addr);
     pop_args(3);
     pushInt32(sockets::socket_send(socket, msg.c_str(), msg_len));
     return true;


### PR DESCRIPTION
Previously `socket_send` would use `strlen` to determine the length of sent strings instead of using the length provided in the argument. For binary data this does not work, instead we should just use the length which was supplied as an argument. 

I discovered this when trying to develop a minecraft server (with the help of some AI) to see what was possible with the TCP sockets. The result is a functional minecraft server running on our VM:

[youtube video](https://www.youtube.com/watch?v=bd140QhqLPY)