### PR TITLE
Allow optionally taking full snapshots on a set interval in tracing mode

### DIFF
--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1082,12 +1082,12 @@ void Debugger::handleSnapshotPolicy(Module *m) {
         // snapshots will be taken) take full checkpoints every
         // checkpointInterval instructions.
         if (checkpoint_state != nullptr) {
-            instructions_since_full_snapshot++;
             if (checkpointInterval != UINT32_MAX &&
                 instructions_since_full_snapshot >= checkpointInterval) {
                 checkpoint(m, true, true);
                 instructions_since_full_snapshot = 0;
             }
+            instructions_since_full_snapshot++;
         }
 
         instructions_executed++;
@@ -1157,6 +1157,11 @@ void Debugger::freeState(Module *m, uint8_t *interruptData) {
     ectx->csp = -1;
     ectx->sp = -1;
     memset(ectx->br_table, 0, BR_TABLE_SIZE);
+
+    // Reset checkpointing counters, new checkpoints will have instructions
+    // executed since this snapshot.
+    instructions_since_full_snapshot = 0;
+    instructions_executed = 0;
 
     while (first_msg < endfm) {
         switch (*first_msg++) {

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -1077,7 +1077,6 @@ void Debugger::handleSnapshotPolicy(Module *m) {
                 }
             }
         }
-        instructions_executed++;
 
         // When using tracing, optionally (if the interval is 0xffffffff no full
         // snapshots will be taken) take full checkpoints every
@@ -1090,6 +1089,8 @@ void Debugger::handleSnapshotPolicy(Module *m) {
                 instructions_since_full_snapshot = 0;
             }
         }
+
+        instructions_executed++;
 
         ExecutionContext *ectx = m->warduino->execution_context;
         // Store arguments of last primitive call.

--- a/src/Debug/debugger.cpp
+++ b/src/Debug/debugger.cpp
@@ -24,6 +24,7 @@ Debugger::Debugger(Channel *duplex) {
     this->snapshotPolicy = SnapshotPolicy::none;
     this->checkpointInterval = 10;
     this->instructions_executed = 0;
+    this->instructions_since_full_snapshot = 0;
     this->fidx_called = {};
     this->min_return_values = 0;
     this->checkpoint_state = nullptr;
@@ -1015,6 +1016,7 @@ void Debugger::setSnapshotPolicy(Module *m, uint8_t *interruptData) {
         }
         checkpoint_state = nullptr;
         checkpoint_state_size = 0;
+        *data_ptr += 1;
     } else {
         snapshotPolicy = SnapshotPolicy::checkpointing;
         *data_ptr += 1;
@@ -1032,8 +1034,9 @@ void Debugger::setSnapshotPolicy(Module *m, uint8_t *interruptData) {
 
     // Make a checkpoint when you first enable checkpointing
     if (snapshotPolicy == SnapshotPolicy::checkpointing) {
-        uint8_t *ptr = *data_ptr + 1;
-        checkpointInterval = read_B32(&ptr);
+        checkpointInterval = read_B32(data_ptr);
+        instructions_executed = 0;
+        instructions_since_full_snapshot = 0;
         checkpoint(m, true);
     }
     printf("ack%x\n", interruptSetSnapshotPolicy);
@@ -1076,6 +1079,18 @@ void Debugger::handleSnapshotPolicy(Module *m) {
         }
         instructions_executed++;
 
+        // When using tracing, optionally (if the interval is 0xffffffff no full
+        // snapshots will be taken) take full checkpoints every
+        // checkpointInterval instructions.
+        if (checkpoint_state != nullptr) {
+            instructions_since_full_snapshot++;
+            if (checkpointInterval != UINT32_MAX &&
+                instructions_since_full_snapshot >= checkpointInterval) {
+                checkpoint(m, true, true);
+                instructions_since_full_snapshot = 0;
+            }
+        }
+
         ExecutionContext *ectx = m->warduino->execution_context;
         // Store arguments of last primitive call.
         if ((fidx_called = getPrimitiveBeingCalled(m, ectx->pc_ptr))) {
@@ -1090,7 +1105,7 @@ void Debugger::handleSnapshotPolicy(Module *m) {
     }
 }
 
-void Debugger::checkpoint(Module *m, const bool force) {
+void Debugger::checkpoint(Module *m, const bool force, const bool full) {
     if (instructions_executed == 0 && !force) {
         return;
     }
@@ -1119,7 +1134,7 @@ void Debugger::checkpoint(Module *m, const bool force) {
         this->channel->write("], ");
     }
     this->channel->write(R"("snapshot": )");
-    if (!checkpoint_state) {
+    if (!checkpoint_state || full) {
         snapshot(m);
     } else {
         inspect(m, checkpoint_state_size, checkpoint_state);
@@ -1661,6 +1676,7 @@ bool Debugger::handleUpdateStackValue(const Module *m, uint8_t *bytes) const {
 bool Debugger::reset(Module *m) {
     m->warduino->reset_module(m);
     instructions_executed = 0;
+    instructions_since_full_snapshot = 0;
     this->channel->write("Reset WARDuino.\n");
     return true;
 }

--- a/src/Debug/debugger.h
+++ b/src/Debug/debugger.h
@@ -155,8 +155,10 @@ class Debugger {
 
     // Checkpointing
     SnapshotPolicy snapshotPolicy;
-    uint32_t checkpointInterval;          // #instructions between checkpoints
-    uint32_t instructions_executed;       // #instructions since last checkpoint
+    uint32_t checkpointInterval;     // #instructions between checkpoints
+    uint32_t instructions_executed;  // #instructions since last checkpoint
+    uint32_t instructions_since_full_snapshot;  // #instructions since last full
+                                                // snapshot
     std::optional<uint32_t> fidx_called;  // The primitive that was executed
     uint32_t prim_args[8];                // The arguments of the executed prim
     uint32_t min_return_values;
@@ -336,6 +338,6 @@ class Debugger {
     bool getMockForArgs(Module *m, uint32_t fidx, uint32_t &result);
 
     // Checkpointing
-    void checkpoint(Module *m, bool force = false);
+    void checkpoint(Module *m, bool force = false, bool full = false);
     inline SnapshotPolicy getSnapshotPolicy() { return snapshotPolicy; }
 };


### PR DESCRIPTION
This allows hybrid snapshot/tracing schemes where you trace most of the execution but still take snapshots every now and then to avoid expensive re-execution.

Example `6103010101000f0000`:
```
  61 03 01 01 01 00 0f 00 00                                                                                                                                                                                                                                                                                               
  │  │  │  │  │  └──────────── checkpointInterval (big-endian u32) = 0x000f0000 = 983 040                                                                                                                                                                                                                                  
  │  │  │  │  └─────────────── checkpoint_state[0] = pcState (0x01)                                                                                                                                                                                                                                                       
  │  │  │  └────────────────── checkpoint_state_size (LEB128) = 1                                                                                                                                                                                                                                                         
  │  │  └───────────────────── min_return_values (LEB128) = 1                                                                                                                                                                                                                                                           
  │  └──────────────────────── policy = 3 → checkpointing                                                                                                                                                                                                                                                               
  └─────────────────────────── interruptSetSnapshotPolicy (0x61)
```
